### PR TITLE
add min_resil_timesteps capability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - include existing capacity in microgrid upgrade cost
 - implement ElectricLoad `loads_kw_is_net` and `critical_loads_kw_is_net`
     - add existing PV production to raw load profile is `true`
+- add min_resil_timesteps input and optional constraint for minimum timesteps that critical load must be met in every outage
 
 ## v0.1.1 Fix build.jl
 deps/build.jl had a relative path dependency, fixed with an absolute path.

--- a/src/constraints/outage_constraints.jl
+++ b/src/constraints/outage_constraints.jl
@@ -38,6 +38,12 @@ function add_dv_UnservedLoad_constraints(m,p)
     )
 end
 
+# constrain minimum hours that critical load is met
+function add_min_hours_crit_ld_met_constraint(m,p)
+    @constraint(m, [s in p.elecutil.scenarios, tz in p.elecutil.outage_start_timesteps, ts in 1:p.min_resil_timesteps],
+        m[:dvUnservedLoad][s, tz, ts] <= 0
+    )
+end
 
 function add_outage_cost_constraints(m,p)
     # TODO: fixed cost, account for outage_is_major_event

--- a/src/core/electric_load.jl
+++ b/src/core/electric_load.jl
@@ -44,7 +44,7 @@ mutable struct ElectricLoad  # mutable to adjust (critical_)loads_kw based off o
         critical_loads_kw::Union{Missing, Array{Real,1}} = missing,
         loads_kw_is_net::Bool = true,
         critical_loads_kw_is_net::Bool = false,
-        critical_load_pct::Float64 = 0.5
+        critical_load_pct::Real = 0.5
         )
         
         if !ismissing(loads_kw)

--- a/src/core/reopt.jl
+++ b/src/core/reopt.jl
@@ -187,6 +187,10 @@ function build_reopt!(m::JuMP.AbstractModel, p::REoptInputs)
 				m[:binMGGenIsOnInTS][s, tz, ts] == 0
 			)
 		end
+		
+		if p.min_resil_timesteps > 0
+			add_min_hours_crit_ld_met_constraint(m,p)
+		end
 	end
 
 

--- a/src/core/reopt_inputs.jl
+++ b/src/core/reopt_inputs.jl
@@ -68,6 +68,7 @@ struct REoptInputs
     storage::Storage
     generator::Generator
     elecutil::ElectricUtility
+    min_resil_timesteps::Int
 end
 
 function REoptInputs(fp::String)
@@ -140,6 +141,7 @@ function REoptInputs(s::Scenario)
         s.storage,
         s.generator,
         s.electric_utility,
+        s.site.min_resil_timesteps
     )
 end
 

--- a/src/core/site.jl
+++ b/src/core/site.jl
@@ -32,9 +32,11 @@ struct Site
     longitude
     land_acres
     roof_squarefeet
+    min_resil_timesteps
     function Site(;latitude::Real, longitude::Real, 
                    land_acres::Union{Float64, Nothing}=nothing, 
-                   roof_squarefeet::Union{Float64, Nothing}=nothing
+                   roof_squarefeet::Union{Float64, Nothing}=nothing,
+                   min_resil_timesteps::Int=0,
         ) 
         invalid_args = String[]
         if !(-90 <= latitude < 90)
@@ -46,6 +48,6 @@ struct Site
         if length(invalid_args) > 0
             error("Invalid argument values: $(invalid_args)")
         end
-        new(latitude, longitude, land_acres, roof_squarefeet)
+        new(latitude, longitude, land_acres, roof_squarefeet, min_resil_timesteps)
     end
 end

--- a/test/scenarios/nogridcost_minresilhours.json
+++ b/test/scenarios/nogridcost_minresilhours.json
@@ -1,0 +1,67 @@
+{
+  "ElectricUtility": {
+    "outage_durations": [
+      169
+    ],
+    "outage_start_timesteps": [
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9,
+      10,
+      11,
+      12
+    ]
+  },
+  "ElectricTariff": {
+    "monthly_demand_rates": [
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "monthly_energy_rates": [
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  "Site": {
+    "latitude": 39.7407,
+    "min_resil_timesteps": 168,
+    "longitude": -105.1686
+  },
+  "ElectricLoad": {
+    "annual_kwh": 8760.0,
+    "doe_reference_name": "FlatLoad",
+    "city": "Boulder",
+    "critical_load_pct": 1
+  },
+  "Generator": {
+  },
+  "Financial": {
+    "VoLL": 0.0
+  }
+}

--- a/test/test_with_cplex.jl
+++ b/test/test_with_cplex.jl
@@ -82,6 +82,14 @@ end
     @test value(m[:binMGTechUsed]["PV"]) == 0
     @test value(m[:binMGStorageUsed]) == 1
     @test results["lcc"] ≈ 6.5789084e7
+    
+    #=
+    Scenario with $0/kWh VoLL, 12x169 hour outages, 1kW load/hour, and min_resil_timesteps = 168
+    - should meet 168 kWh in each outage such that the total unserved load is 12 kWh
+    =#
+    m = Model(optimizer_with_attributes(CPLEX.Optimizer, "CPX_PARAM_SCRIND" => 0))
+    results = run_reopt(m, ".test/scenarios/nogridcost_minresilhours.json")
+    @test results["total_unserved_load"] ≈ 12
 end
 
 

--- a/test/test_with_xpress.jl
+++ b/test/test_with_xpress.jl
@@ -89,6 +89,14 @@ end
     @test value(m[:binMGTechUsed]["PV"]) == 0
     @test value(m[:binMGStorageUsed]) == 1
     @test results["lcc"] ≈ 6.5789084e7
+    
+    #=
+    Scenario with $0/kWh VoLL, 12x169 hour outages, 1kW load/hour, and min_resil_timesteps = 168
+    - should meet 168 kWh in each outage such that the total unserved load is 12 kWh
+    =#
+    m = Model(optimizer_with_attributes(Xpress.Optimizer, "OUTPUTLOG" => 0))
+    results = run_reopt(m, ".test/scenarios/nogridcost_minresilhours.json")
+    @test results["total_unserved_load"] ≈ 12
 end
 
 ## equivalent REopt Lite API Post for test 2:

--- a/test/test_with_xpress.jl
+++ b/test/test_with_xpress.jl
@@ -95,7 +95,7 @@ end
     - should meet 168 kWh in each outage such that the total unserved load is 12 kWh
     =#
     m = Model(optimizer_with_attributes(Xpress.Optimizer, "OUTPUTLOG" => 0))
-    results = run_reopt(m, ".test/scenarios/nogridcost_minresilhours.json")
+    results = run_reopt(m, "./scenarios/nogridcost_minresilhours.json")
     @test results["total_unserved_load"] ≈ 12
 end
 


### PR DESCRIPTION
new input field for Site that sets the minimum number of time steps that the critical load must be met in every outage