### PR TITLE
add dvMGsize[techs] 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # REoptLite Changelog
 
+## dev
+- add separate decision variables and constraints for microgrid tech capacities
+    - new Site input `mg_tech_sizes_equal_grid_sizes` (boolean), when `false` the microgrid tech capacities are constrained to be <= the grid connected tech capacities
+
 ## v0.2.0
 #### Improvements
 - add support for custom ElectricLoad `loads_kw` input

--- a/src/constraints/outage_constraints.jl
+++ b/src/constraints/outage_constraints.jl
@@ -57,24 +57,41 @@ function add_outage_cost_constraints(m,p)
 
     @constraint(m, [t in p.techs],
         m[:binMGTechUsed][t] => {m[:dvMGTechUpgradeCost][t] >= p.microgrid_premium_pct * p.two_party_factor *
-		                         p.cap_cost_slope[t] * m[:dvSize][t]}
-    )
-
-    @constraint(m, [t in p.techs],
-        m[:binMGTechUsed][t] => {m[:dvSize][t] >= 1.0}  # 1 kW min size to prevent binaryMGTechUsed = 1 with zero cost
+		                         p.cap_cost_slope[t] * m[:dvMGsize][t]}
     )
 
     @constraint(m,
         m[:binMGStorageUsed] => {m[:dvMGStorageUpgradeCost] >= p.microgrid_premium_pct * m[:TotalStorageCapCosts]}
     )
-
-    @constraint(m, [b in p.storage.types],
-        m[:binMGStorageUsed] => {m[:dvStoragePower][b] >= 1.0} # 1 kW min size to prevent binaryMGStorageUsed = 1 with zero cost
-    )
     
     @expression(m, mgTotalTechUpgradeCost,
         sum( m[:dvMGTechUpgradeCost][t] for t in p.techs )
     )
+end
+
+
+function add_MG_size_constraints(m,p)
+    @constraint(m, [t in p.techs],
+        m[:binMGTechUsed][t] => {m[:dvMGsize][t] >= 1.0}  # 1 kW min size to prevent binaryMGTechUsed = 1 with zero cost
+    )
+
+    @constraint(m, [b in p.storage.types],
+        m[:binMGStorageUsed] => {m[:dvStoragePower][b] >= 1.0} # 1 kW min size to prevent binaryMGStorageUsed = 1 with zero cost
+    )
+    @info "p.mg_tech_sizes_equal_grid_sizes", p.mg_tech_sizes_equal_grid_sizes
+    if p.mg_tech_sizes_equal_grid_sizes
+        @info "here"
+        @constraint(m, [t in p.techs],
+            m[:dvMGsize][t] == m[:dvSize][t]
+        )
+    else
+        @info "there"
+        @constraint(m, [t in p.techs],
+            m[:dvMGsize][t] <= m[:dvSize][t]
+        )
+    end
+        
+    
 end
 
 
@@ -101,7 +118,7 @@ function add_MG_production_constraints(m,p)
     end
     
     @constraint(m, [t in p.techs, s in p.elecutil.scenarios, tz in p.elecutil.outage_start_timesteps, ts in p.elecutil.outage_timesteps],
-        m[:dvMGRatedProduction][t, s, tz, ts] <= m[:dvSize][t]
+        m[:dvMGRatedProduction][t, s, tz, ts] <= m[:dvMGsize][t]
     )
 end
 
@@ -145,13 +162,13 @@ end
 
 function add_binMGGenIsOnInTS_constraints(m,p)
     # The following 2 constraints define binMGGenIsOnInTS to be the binary corollary to dvMGRatedProd for generator,
-    # i.e. binMGGenIsOnInTS = 1 for dvMGRatedProd > min_turn_down_pct * dvSize, and binMGGenIsOnInTS = 0 for dvMGRatedProd = 0
+    # i.e. binMGGenIsOnInTS = 1 for dvMGRatedProd > min_turn_down_pct * dvMGsize, and binMGGenIsOnInTS = 0 for dvMGRatedProd = 0
     @constraint(m, [t in p.gentechs, s in p.elecutil.scenarios, tz in p.elecutil.outage_start_timesteps, ts in p.elecutil.outage_timesteps],
         !m[:binMGGenIsOnInTS][s, tz, ts] => { m[:dvMGRatedProduction][t, s, tz, ts] <= 0 }
     )
     @constraint(m, [t in p.gentechs, s in p.elecutil.scenarios, tz in p.elecutil.outage_start_timesteps, ts in p.elecutil.outage_timesteps],
         m[:binMGGenIsOnInTS][s, tz, ts] => { 
-            m[:dvMGRatedProduction][t, s, tz, ts] >= p.generator.min_turn_down_pct * m[:dvSize][t]
+            m[:dvMGRatedProduction][t, s, tz, ts] >= p.generator.min_turn_down_pct * m[:dvMGsize][t]
         }
     )
     @constraint(m, [t in p.gentechs, s in p.elecutil.scenarios, tz in p.elecutil.outage_start_timesteps, ts in p.elecutil.outage_timesteps],
@@ -218,7 +235,7 @@ function add_cannot_have_MG_with_only_PVwind_constraints(m, p)
     # can't "turn down" renewable_techs
     if !isempty(renewable_techs)
         @constraint(m, [t in renewable_techs, s in p.elecutil.scenarios, tz in p.elecutil.outage_start_timesteps, ts in p.elecutil.outage_timesteps],
-            m[:binMGTechUsed][t] => { m[:dvMGRatedProduction][t, s, tz, ts] >= m[:dvSize][t] }
+            m[:binMGTechUsed][t] => { m[:dvMGRatedProduction][t, s, tz, ts] >= m[:dvMGsize][t] }
         )
         @constraint(m, [t in renewable_techs, s in p.elecutil.scenarios, tz in p.elecutil.outage_start_timesteps, ts in p.elecutil.outage_timesteps],
             !m[:binMGTechUsed][t] => { m[:dvMGRatedProduction][t, s, tz, ts] <= 0 }

--- a/src/core/reopt.jl
+++ b/src/core/reopt.jl
@@ -176,6 +176,7 @@ function build_reopt!(m::JuMP.AbstractModel, p::REoptInputs)
 		add_MG_production_constraints(m,p)
 		add_MG_storage_dispatch_constraints(m,p)
 		add_cannot_have_MG_with_only_PVwind_constraints(m,p)
+		add_MG_size_constraints(m,p)
 		
 		if !isempty(p.gentechs)
 			add_MG_fuel_burn_constraints(m,p)
@@ -430,6 +431,7 @@ function add_variables!(m::JuMP.AbstractModel, p::REoptInputs)
 			dvMaxOutageCost[S] >= 0 # maximum outage cost dependent on number of outage durations
 			dvMGTechUpgradeCost[p.techs] >= 0
 			dvMGStorageUpgradeCost >= 0
+			dvMGsize[p.techs] >= 0
 			
 			dvMGFuelUsed[p.techs, S, tZeros] >= 0
 			dvMGMaxFuelUsage[S] >= 0
@@ -496,4 +498,11 @@ end
 function add_outage_results(m, p, r::Dict)
 	r["expected_outage_cost"] = value(m[:ExpectedOutageCost])
 	r["total_unserved_load"] = sum(value.(m[:dvUnservedLoad]))
+	
+	if !isempty(p.pvtechs)
+		for t in p.pvtechs
+			# TODO add microgrid dispatch results as well as other MG results
+			r[string(t, "mg_kw")] = round(value(m[:dvMGsize][t]), digits=4)
+		end
+	end
 end

--- a/src/core/reopt_inputs.jl
+++ b/src/core/reopt_inputs.jl
@@ -69,6 +69,7 @@ struct REoptInputs
     generator::Generator
     elecutil::ElectricUtility
     min_resil_timesteps::Int
+    mg_tech_sizes_equal_grid_sizes::Bool
 end
 
 function REoptInputs(fp::String)
@@ -141,7 +142,8 @@ function REoptInputs(s::Scenario)
         s.storage,
         s.generator,
         s.electric_utility,
-        s.site.min_resil_timesteps
+        s.site.min_resil_timesteps,
+        s.site.mg_tech_sizes_equal_grid_sizes
     )
 end
 

--- a/src/core/site.jl
+++ b/src/core/site.jl
@@ -33,11 +33,15 @@ struct Site
     land_acres
     roof_squarefeet
     min_resil_timesteps
-    function Site(;latitude::Real, longitude::Real, 
-                   land_acres::Union{Float64, Nothing}=nothing, 
-                   roof_squarefeet::Union{Float64, Nothing}=nothing,
-                   min_resil_timesteps::Int=0,
-        ) 
+    mg_tech_sizes_equal_grid_sizes
+    function Site(;
+        latitude::Real, 
+        longitude::Real, 
+        land_acres::Union{Float64, Nothing}=nothing, 
+        roof_squarefeet::Union{Float64, Nothing}=nothing,
+        min_resil_timesteps::Int=0,
+        mg_tech_sizes_equal_grid_sizes::Bool = true
+        )
         invalid_args = String[]
         if !(-90 <= latitude < 90)
             push!(invalid_args, "latitude must satisfy -90 <= latitude < 90, got $(latitude)")
@@ -48,6 +52,7 @@ struct Site
         if length(invalid_args) > 0
             error("Invalid argument values: $(invalid_args)")
         end
-        new(latitude, longitude, land_acres, roof_squarefeet, min_resil_timesteps)
+        new(latitude, longitude, land_acres, roof_squarefeet, min_resil_timesteps, 
+            mg_tech_sizes_equal_grid_sizes)
     end
 end


### PR DESCRIPTION
Now microgrid tech sizes can (optionally) be allowed to be less than the grid optimal `dvSize[techs]` using new input `Site. mg_tech_sizes_equal_grid_sizes`