### PR TITLE
Outage scenario bug fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## dev
 - add separate decision variables and constraints for microgrid tech capacities
     - new Site input `mg_tech_sizes_equal_grid_sizes` (boolean), when `false` the microgrid tech capacities are constrained to be <= the grid connected tech capacities
+#### bug fixes
+- allow non-integer `outage_probabilities`
+- correct `total_unserved_load` output
+- don't `add_min_hours_crit_ld_met_constraint` unless `min_resil_timesteps <= length(elecutil.outage_timesteps)`
 
 ## v0.2.0
 #### Improvements

--- a/src/constraints/outage_constraints.jl
+++ b/src/constraints/outage_constraints.jl
@@ -78,20 +78,16 @@ function add_MG_size_constraints(m,p)
     @constraint(m, [b in p.storage.types],
         m[:binMGStorageUsed] => {m[:dvStoragePower][b] >= 1.0} # 1 kW min size to prevent binaryMGStorageUsed = 1 with zero cost
     )
-    @info "p.mg_tech_sizes_equal_grid_sizes", p.mg_tech_sizes_equal_grid_sizes
+    
     if p.mg_tech_sizes_equal_grid_sizes
-        @info "here"
         @constraint(m, [t in p.techs],
             m[:dvMGsize][t] == m[:dvSize][t]
         )
     else
-        @info "there"
         @constraint(m, [t in p.techs],
             m[:dvMGsize][t] <= m[:dvSize][t]
         )
     end
-        
-    
 end
 
 

--- a/src/constraints/outage_constraints.jl
+++ b/src/constraints/outage_constraints.jl
@@ -40,9 +40,11 @@ end
 
 # constrain minimum hours that critical load is met
 function add_min_hours_crit_ld_met_constraint(m,p)
-    @constraint(m, [s in p.elecutil.scenarios, tz in p.elecutil.outage_start_timesteps, ts in 1:p.min_resil_timesteps],
-        m[:dvUnservedLoad][s, tz, ts] <= 0
-    )
+    if p.min_resil_timesteps <= length(p.elecutil.outage_timesteps)
+        @constraint(m, [s in p.elecutil.scenarios, tz in p.elecutil.outage_start_timesteps, ts in 1:p.min_resil_timesteps],
+            m[:dvUnservedLoad][s, tz, ts] <= 0
+        )
+    end
 end
 
 function add_outage_cost_constraints(m,p)

--- a/src/core/electric_utility.jl
+++ b/src/core/electric_utility.jl
@@ -34,7 +34,7 @@ Base.@kwdef struct ElectricUtility
     # with max taken over outage start time, expectation taken over outage duration
     outage_start_timesteps::Array{Int,1}=Int[]  # we minimize the maximum outage cost over outage start times
     outage_durations::Array{Int,1}=Int[]  # one-to-one with outage_probabilities, outage_durations can be a random variable
-    outage_probabilities::Array{Int,1}=[1.0]
+    outage_probabilities::Array{Real,1}=[1.0]
     outage_timesteps::Union{Missing, UnitRange} = isempty(outage_durations) ? missing : 1:maximum(outage_durations)
     scenarios::Union{Missing, UnitRange} = isempty(outage_durations) ? missing : 1:length(outage_durations)
 end

--- a/src/core/reopt.jl
+++ b/src/core/reopt.jl
@@ -497,7 +497,14 @@ end
 
 function add_outage_results(m, p, r::Dict)
 	r["expected_outage_cost"] = value(m[:ExpectedOutageCost])
-	r["total_unserved_load"] = sum(value.(m[:dvUnservedLoad]))
+	r["total_unserved_load"] = 0
+	for s in p.elecutil.scenarios
+		r["total_unserved_load"] += sum(value.(m[:dvUnservedLoad])[s, tz, ts]
+			for tz in p.elecutil.outage_start_timesteps, 
+				ts in 1:p.elecutil.outage_durations[s]
+		) # need the ts in 1:p.elecutil.outage_durations[s] b/c dvUnservedLoad has unused values in third dimension
+	end
+	r["total_unserved_load"] = round(r["total_unserved_load"], digits=2)
 	
 	if !isempty(p.pvtechs)
 		for t in p.pvtechs

--- a/test/scenarios/nogridcost_multiscenario.json
+++ b/test/scenarios/nogridcost_multiscenario.json
@@ -1,0 +1,60 @@
+{
+  "ElectricUtility": {
+    "outage_durations": [
+      1,
+      5
+    ],
+    "outage_start_timesteps": [
+      10
+    ],
+    "outage_probabilities": [
+      0.5,
+      0.5
+    ]
+  },
+  "ElectricTariff": {
+    "monthly_demand_rates": [
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "monthly_energy_rates": [
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  "Site": {
+    "latitude": 39.7407,
+    "longitude": -105.1686
+  },
+  "ElectricLoad": {
+    "annual_kwh": 876000.0,
+    "doe_reference_name": "FlatLoad",
+    "city": "Boulder",
+    "critical_load_pct": 0.1
+  },
+  "Generator": {
+  },
+  "Financial": {
+    "VoLL": 0.0
+  }
+}

--- a/test/test_with_xpress.jl
+++ b/test/test_with_xpress.jl
@@ -97,6 +97,12 @@ end
     m = Model(optimizer_with_attributes(Xpress.Optimizer, "OUTPUTLOG" => 0))
     results = run_reopt(m, "./scenarios/nogridcost_minresilhours.json")
     @test results["total_unserved_load"] ≈ 12
+    
+    # testing dvUnserved load, which would output 100 kWh for this scenario before output fix
+    m = Model(optimizer_with_attributes(Xpress.Optimizer, "OUTPUTLOG" => 0))
+    results = run_reopt(m, "./scenarios/nogridcost_multiscenario.json")
+    @test results["total_unserved_load"] ≈ 60
+    
 end
 
 ## equivalent REopt Lite API Post for test 2:


### PR DESCRIPTION
#### bug fixes
- allow non-integer `outage_probabilities`
- correct `total_unserved_load` output
- don't `add_min_hours_crit_ld_met_constraint` unless `min_resil_timesteps <= length(elecutil.outage_timesteps)`