### PR TITLE
v0.30 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## dev
 - add separate decision variables and constraints for microgrid tech capacities
     - new Site input `mg_tech_sizes_equal_grid_sizes` (boolean), when `false` the microgrid tech capacities are constrained to be <= the grid connected tech capacities
+#### bug fixes
+- allow non-integer `outage_probabilities`
+- correct `total_unserved_load` output
+- don't `add_min_hours_crit_ld_met_constraint` unless `min_resil_timesteps <= length(elecutil.outage_timesteps)`
 
 ## v0.2.0
 #### Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # REoptLite Changelog
 
-## dev
+## v0.3.0
+#### Improvements
 - add separate decision variables and constraints for microgrid tech capacities
     - new Site input `mg_tech_sizes_equal_grid_sizes` (boolean), when `false` the microgrid tech capacities are constrained to be <= the grid connected tech capacities
 #### bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # REoptLite Changelog
 
+## dev
+- add separate decision variables and constraints for microgrid tech capacities
+    - new Site input `mg_tech_sizes_equal_grid_sizes` (boolean), when `false` the microgrid tech capacities are constrained to be <= the grid connected tech capacities
+
 ## v0.2.0
 #### Improvements
 - add support for custom ElectricLoad `loads_kw` input

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "REoptLite"
 uuid = "0144022d-7626-48b7-867b-06d945449d75"
 authors = ["Nick Laws <nick.laws@nrel.gov>"]
-version = "0.2.0"
+version = "0.3.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Note: this package has been tested only with Julia 1.4 and may not be compatible
 The full details of the model will be published in _Laws et al. 2020, Cost-Optimal Microgrid Planning Under Uncertain Grid Reliability, [Draft]_. In brief, the model is set up to minimize the maximum expected outage cost (while minimizing the lifecycle cost of energy including utility tariff costs), where the maximum is taken over outage start times, and the expectation is taken over outage durations.
 
 ## Usage
-Evaluating only `PV` and `Storage` requires a linear program solver. Adding a generator and/or multiple outages makes the problem mixed-integer linear, and thus requires a MILP solver. See https://jump.dev/JuMP.jl/stable/installation/ for a list of solvers. The REopt Lite package has been tested with `Xpress` and `CPLEX`.
+Evaluating only `PV` and `Storage` requires a linear program solver. Adding a generator and/or multiple outages makes the problem mixed-integer linear, and thus requires a MILP solver. See https://jump.dev/JuMP.jl/stable/installation/ for a list of solvers. The REopt Lite package has been tested with `Xpress`, `Cbc` and `CPLEX`.
 ### Example
 ```
 using Xpress

--- a/src/constraints/outage_constraints.jl
+++ b/src/constraints/outage_constraints.jl
@@ -80,12 +80,10 @@ function add_MG_size_constraints(m,p)
     )
     @info "p.mg_tech_sizes_equal_grid_sizes", p.mg_tech_sizes_equal_grid_sizes
     if p.mg_tech_sizes_equal_grid_sizes
-        @info "here"
         @constraint(m, [t in p.techs],
             m[:dvMGsize][t] == m[:dvSize][t]
         )
     else
-        @info "there"
         @constraint(m, [t in p.techs],
             m[:dvMGsize][t] <= m[:dvSize][t]
         )

--- a/src/constraints/outage_constraints.jl
+++ b/src/constraints/outage_constraints.jl
@@ -40,9 +40,11 @@ end
 
 # constrain minimum hours that critical load is met
 function add_min_hours_crit_ld_met_constraint(m,p)
-    @constraint(m, [s in p.elecutil.scenarios, tz in p.elecutil.outage_start_timesteps, ts in 1:p.min_resil_timesteps],
-        m[:dvUnservedLoad][s, tz, ts] <= 0
-    )
+    if p.min_resil_timesteps <= length(p.elecutil.outage_timesteps)
+        @constraint(m, [s in p.elecutil.scenarios, tz in p.elecutil.outage_start_timesteps, ts in 1:p.min_resil_timesteps],
+            m[:dvUnservedLoad][s, tz, ts] <= 0
+        )
+    end
 end
 
 function add_outage_cost_constraints(m,p)
@@ -78,7 +80,7 @@ function add_MG_size_constraints(m,p)
     @constraint(m, [b in p.storage.types],
         m[:binMGStorageUsed] => {m[:dvStoragePower][b] >= 1.0} # 1 kW min size to prevent binaryMGStorageUsed = 1 with zero cost
     )
-    @info "p.mg_tech_sizes_equal_grid_sizes", p.mg_tech_sizes_equal_grid_sizes
+    
     if p.mg_tech_sizes_equal_grid_sizes
         @constraint(m, [t in p.techs],
             m[:dvMGsize][t] == m[:dvSize][t]
@@ -88,8 +90,6 @@ function add_MG_size_constraints(m,p)
             m[:dvMGsize][t] <= m[:dvSize][t]
         )
     end
-        
-    
 end
 
 

--- a/src/constraints/outage_constraints.jl
+++ b/src/constraints/outage_constraints.jl
@@ -57,24 +57,41 @@ function add_outage_cost_constraints(m,p)
 
     @constraint(m, [t in p.techs],
         m[:binMGTechUsed][t] => {m[:dvMGTechUpgradeCost][t] >= p.microgrid_premium_pct * p.two_party_factor *
-		                         p.cap_cost_slope[t] * m[:dvSize][t]}
-    )
-
-    @constraint(m, [t in p.techs],
-        m[:binMGTechUsed][t] => {m[:dvSize][t] >= 1.0}  # 1 kW min size to prevent binaryMGTechUsed = 1 with zero cost
+		                         p.cap_cost_slope[t] * m[:dvMGsize][t]}
     )
 
     @constraint(m,
         m[:binMGStorageUsed] => {m[:dvMGStorageUpgradeCost] >= p.microgrid_premium_pct * m[:TotalStorageCapCosts]}
     )
-
-    @constraint(m, [b in p.storage.types],
-        m[:binMGStorageUsed] => {m[:dvStoragePower][b] >= 1.0} # 1 kW min size to prevent binaryMGStorageUsed = 1 with zero cost
-    )
     
     @expression(m, mgTotalTechUpgradeCost,
         sum( m[:dvMGTechUpgradeCost][t] for t in p.techs )
     )
+end
+
+
+function add_MG_size_constraints(m,p)
+    @constraint(m, [t in p.techs],
+        m[:binMGTechUsed][t] => {m[:dvMGsize][t] >= 1.0}  # 1 kW min size to prevent binaryMGTechUsed = 1 with zero cost
+    )
+
+    @constraint(m, [b in p.storage.types],
+        m[:binMGStorageUsed] => {m[:dvStoragePower][b] >= 1.0} # 1 kW min size to prevent binaryMGStorageUsed = 1 with zero cost
+    )
+    @info "p.mg_tech_sizes_equal_grid_sizes", p.mg_tech_sizes_equal_grid_sizes
+    if p.mg_tech_sizes_equal_grid_sizes
+        @info "here"
+        @constraint(m, [t in p.techs],
+            m[:dvMGsize][t] == m[:dvSize][t]
+        )
+    else
+        @info "there"
+        @constraint(m, [t in p.techs],
+            m[:dvMGsize][t] <= m[:dvSize][t]
+        )
+    end
+        
+    
 end
 
 
@@ -101,7 +118,7 @@ function add_MG_production_constraints(m,p)
     end
     
     @constraint(m, [t in p.techs, s in p.elecutil.scenarios, tz in p.elecutil.outage_start_timesteps, ts in p.elecutil.outage_timesteps],
-        m[:dvMGRatedProduction][t, s, tz, ts] <= m[:dvSize][t]
+        m[:dvMGRatedProduction][t, s, tz, ts] <= m[:dvMGsize][t]
     )
 end
 
@@ -145,13 +162,13 @@ end
 
 function add_binMGGenIsOnInTS_constraints(m,p)
     # The following 2 constraints define binMGGenIsOnInTS to be the binary corollary to dvMGRatedProd for generator,
-    # i.e. binMGGenIsOnInTS = 1 for dvMGRatedProd > min_turn_down_pct * dvSize, and binMGGenIsOnInTS = 0 for dvMGRatedProd = 0
+    # i.e. binMGGenIsOnInTS = 1 for dvMGRatedProd > min_turn_down_pct * dvMGsize, and binMGGenIsOnInTS = 0 for dvMGRatedProd = 0
     @constraint(m, [t in p.gentechs, s in p.elecutil.scenarios, tz in p.elecutil.outage_start_timesteps, ts in p.elecutil.outage_timesteps],
         !m[:binMGGenIsOnInTS][s, tz, ts] => { m[:dvMGRatedProduction][t, s, tz, ts] <= 0 }
     )
     @constraint(m, [t in p.gentechs, s in p.elecutil.scenarios, tz in p.elecutil.outage_start_timesteps, ts in p.elecutil.outage_timesteps],
         m[:binMGGenIsOnInTS][s, tz, ts] => { 
-            m[:dvMGRatedProduction][t, s, tz, ts] >= p.generator.min_turn_down_pct * m[:dvSize][t]
+            m[:dvMGRatedProduction][t, s, tz, ts] >= p.generator.min_turn_down_pct * m[:dvMGsize][t]
         }
     )
     @constraint(m, [t in p.gentechs, s in p.elecutil.scenarios, tz in p.elecutil.outage_start_timesteps, ts in p.elecutil.outage_timesteps],
@@ -218,7 +235,7 @@ function add_cannot_have_MG_with_only_PVwind_constraints(m, p)
     # can't "turn down" renewable_techs
     if !isempty(renewable_techs)
         @constraint(m, [t in renewable_techs, s in p.elecutil.scenarios, tz in p.elecutil.outage_start_timesteps, ts in p.elecutil.outage_timesteps],
-            m[:binMGTechUsed][t] => { m[:dvMGRatedProduction][t, s, tz, ts] >= m[:dvSize][t] }
+            m[:binMGTechUsed][t] => { m[:dvMGRatedProduction][t, s, tz, ts] >= m[:dvMGsize][t] }
         )
         @constraint(m, [t in renewable_techs, s in p.elecutil.scenarios, tz in p.elecutil.outage_start_timesteps, ts in p.elecutil.outage_timesteps],
             !m[:binMGTechUsed][t] => { m[:dvMGRatedProduction][t, s, tz, ts] <= 0 }

--- a/src/core/electric_load.jl
+++ b/src/core/electric_load.jl
@@ -39,7 +39,7 @@ mutable struct ElectricLoad  # mutable to adjust (critical_)loads_kw based off o
         year::Int = 2019,
         doe_reference_name::Union{Missing, String} = missing,
         city::Union{Missing, String} = missing,
-        annual_kwh::Union{Float64, Nothing} = nothing,
+        annual_kwh::Union{Real, Nothing} = nothing,
         monthly_totals_kwh::Array{<:Real,1} = Real[],
         critical_loads_kw::Union{Missing, Array{Real,1}} = missing,
         loads_kw_is_net::Bool = true,

--- a/src/core/electric_utility.jl
+++ b/src/core/electric_utility.jl
@@ -34,7 +34,7 @@ Base.@kwdef struct ElectricUtility
     # with max taken over outage start time, expectation taken over outage duration
     outage_start_timesteps::Array{Int,1}=Int[]  # we minimize the maximum outage cost over outage start times
     outage_durations::Array{Int,1}=Int[]  # one-to-one with outage_probabilities, outage_durations can be a random variable
-    outage_probabilities::Array{Int,1}=[1.0]
+    outage_probabilities::Array{Real,1}=[1.0]
     outage_timesteps::Union{Missing, UnitRange} = isempty(outage_durations) ? missing : 1:maximum(outage_durations)
     scenarios::Union{Missing, UnitRange} = isempty(outage_durations) ? missing : 1:length(outage_durations)
 end

--- a/src/core/reopt.jl
+++ b/src/core/reopt.jl
@@ -176,6 +176,7 @@ function build_reopt!(m::JuMP.AbstractModel, p::REoptInputs)
 		add_MG_production_constraints(m,p)
 		add_MG_storage_dispatch_constraints(m,p)
 		add_cannot_have_MG_with_only_PVwind_constraints(m,p)
+		add_MG_size_constraints(m,p)
 		
 		if !isempty(p.gentechs)
 			add_MG_fuel_burn_constraints(m,p)
@@ -430,6 +431,7 @@ function add_variables!(m::JuMP.AbstractModel, p::REoptInputs)
 			dvMaxOutageCost[S] >= 0 # maximum outage cost dependent on number of outage durations
 			dvMGTechUpgradeCost[p.techs] >= 0
 			dvMGStorageUpgradeCost >= 0
+			dvMGsize[p.techs] >= 0
 			
 			dvMGFuelUsed[p.techs, S, tZeros] >= 0
 			dvMGMaxFuelUsage[S] >= 0
@@ -496,4 +498,11 @@ end
 function add_outage_results(m, p, r::Dict)
 	r["expected_outage_cost"] = value(m[:ExpectedOutageCost])
 	r["total_unserved_load"] = sum(value.(m[:dvUnservedLoad]))
+	
+	if !isempty(p.pvtechs)
+		for t in p.pvtechs
+			# TODO add microgrid dispatch results as well as other MG results
+			r[string(t, "mg_kw")] = round(value(m[:dvMGsize][t]), digits=4)
+		end
+	end
 end

--- a/src/core/reopt.jl
+++ b/src/core/reopt.jl
@@ -497,7 +497,14 @@ end
 
 function add_outage_results(m, p, r::Dict)
 	r["expected_outage_cost"] = value(m[:ExpectedOutageCost])
-	r["total_unserved_load"] = sum(value.(m[:dvUnservedLoad]))
+	r["total_unserved_load"] = 0
+	for s in p.elecutil.scenarios
+		r["total_unserved_load"] += sum(value.(m[:dvUnservedLoad])[s, tz, ts]
+			for tz in p.elecutil.outage_start_timesteps, 
+				ts in 1:p.elecutil.outage_durations[s]
+		) # need the ts in 1:p.elecutil.outage_durations[s] b/c dvUnservedLoad has unused values in third dimension
+	end
+	r["total_unserved_load"] = round(r["total_unserved_load"], digits=2)
 	
 	if !isempty(p.pvtechs)
 		for t in p.pvtechs

--- a/src/core/reopt_inputs.jl
+++ b/src/core/reopt_inputs.jl
@@ -69,6 +69,7 @@ struct REoptInputs
     generator::Generator
     elecutil::ElectricUtility
     min_resil_timesteps::Int
+    mg_tech_sizes_equal_grid_sizes::Bool
 end
 
 function REoptInputs(fp::String)
@@ -141,7 +142,8 @@ function REoptInputs(s::Scenario)
         s.storage,
         s.generator,
         s.electric_utility,
-        s.site.min_resil_timesteps
+        s.site.min_resil_timesteps,
+        s.site.mg_tech_sizes_equal_grid_sizes
     )
 end
 

--- a/src/core/site.jl
+++ b/src/core/site.jl
@@ -33,11 +33,15 @@ struct Site
     land_acres
     roof_squarefeet
     min_resil_timesteps
-    function Site(;latitude::Real, longitude::Real, 
-                   land_acres::Union{Float64, Nothing}=nothing, 
-                   roof_squarefeet::Union{Float64, Nothing}=nothing,
-                   min_resil_timesteps::Int=0,
-        ) 
+    mg_tech_sizes_equal_grid_sizes
+    function Site(;
+        latitude::Real, 
+        longitude::Real, 
+        land_acres::Union{Float64, Nothing}=nothing, 
+        roof_squarefeet::Union{Float64, Nothing}=nothing,
+        min_resil_timesteps::Int=0,
+        mg_tech_sizes_equal_grid_sizes::Bool = true
+        )
         invalid_args = String[]
         if !(-90 <= latitude < 90)
             push!(invalid_args, "latitude must satisfy -90 <= latitude < 90, got $(latitude)")
@@ -48,6 +52,7 @@ struct Site
         if length(invalid_args) > 0
             error("Invalid argument values: $(invalid_args)")
         end
-        new(latitude, longitude, land_acres, roof_squarefeet, min_resil_timesteps)
+        new(latitude, longitude, land_acres, roof_squarefeet, min_resil_timesteps, 
+            mg_tech_sizes_equal_grid_sizes)
     end
 end

--- a/test/scenarios/nogridcost_multiscenario.json
+++ b/test/scenarios/nogridcost_multiscenario.json
@@ -1,0 +1,60 @@
+{
+  "ElectricUtility": {
+    "outage_durations": [
+      1,
+      5
+    ],
+    "outage_start_timesteps": [
+      10
+    ],
+    "outage_probabilities": [
+      0.5,
+      0.5
+    ]
+  },
+  "ElectricTariff": {
+    "monthly_demand_rates": [
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "monthly_energy_rates": [
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  "Site": {
+    "latitude": 39.7407,
+    "longitude": -105.1686
+  },
+  "ElectricLoad": {
+    "annual_kwh": 876000.0,
+    "doe_reference_name": "FlatLoad",
+    "city": "Boulder",
+    "critical_load_pct": 0.1
+  },
+  "Generator": {
+  },
+  "Financial": {
+    "VoLL": 0.0
+  }
+}

--- a/test/test_with_xpress.jl
+++ b/test/test_with_xpress.jl
@@ -97,6 +97,12 @@ end
     m = Model(optimizer_with_attributes(Xpress.Optimizer, "OUTPUTLOG" => 0))
     results = run_reopt(m, "./scenarios/nogridcost_minresilhours.json")
     @test results["total_unserved_load"] ≈ 12
+    
+    # testing dvUnserved load, which would output 100 kWh for this scenario before output fix
+    m = Model(optimizer_with_attributes(Xpress.Optimizer, "OUTPUTLOG" => 0))
+    results = run_reopt(m, "./scenarios/nogridcost_multiscenario.json")
+    @test results["total_unserved_load"] ≈ 60
+    
 end
 
 ## equivalent REopt Lite API Post for test 2:


### PR DESCRIPTION
#### Improvements
- add separate decision variables and constraints for microgrid tech capacities
    - new Site input `mg_tech_sizes_equal_grid_sizes` (boolean), when `false` the microgrid tech capacities are constrained to be <= the grid connected tech capacities
#### bug fixes
- allow non-integer `outage_probabilities`
- correct `total_unserved_load` output
- don't `add_min_hours_crit_ld_met_constraint` unless `min_resil_timesteps <= length(elecutil.outage_timesteps)`