### PR TITLE
master <- develop outage simulator, outage outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # REoptLite Changelog
 
+## v0.4.0
+#### Improvements
+- add `simulate_outages` function (similar to REopt Lite API outage simulator)
+- removed MutableArithmetics package from Project.toml (since JuMP now has method for `value(::MutableArithmetics.Zero)`)
+- added outage related outputs:
+    - Generator_mg_kw
+    - mg_Generator_upgrade_cost
+    - mg_Generator_fuel_used
+    - mg_PV_upgrade_cost
+    - mg_storage_upgrade_cost
+    - dvUnservedLoad array
+    - max_outage_cost_per_outage_duration
+- allow VoLL values to be subtype of Real (rather than only Real)
+- add `run_reopt` method for scenario Dict
+
 ## v0.3.0
 #### Improvements
 - add separate decision variables and constraints for microgrid tech capacities

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -11,9 +11,9 @@ version = "0.5.0"
 
 [[Bzip2_jll]]
 deps = ["Libdl", "Pkg"]
-git-tree-sha1 = "3663bfffede2ef41358b6fc2e1d8a6d50b3c3904"
+git-tree-sha1 = "03a44490020826950c68005cafb336e5ba08b7e8"
 uuid = "6e34b625-4abd-537c-b88f-471c36dfa7a0"
-version = "1.0.6+2"
+version = "1.0.6+4"
 
 [[Calculus]]
 deps = ["LinearAlgebra"]
@@ -39,6 +39,12 @@ git-tree-sha1 = "7b8a93dba8af7e3b42fecabf646260105ac373f7"
 uuid = "bbf7d656-a473-5ed7-a52c-81e309532950"
 version = "0.3.0"
 
+[[Compat]]
+deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "SHA", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Statistics", "Test", "UUIDs", "Unicode"]
+git-tree-sha1 = "7c7f4cda0d58ec999189d70f5ee500348c4b4df1"
+uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
+version = "3.16.0"
+
 [[CompilerSupportLibraries_jll]]
 deps = ["Libdl", "Pkg"]
 git-tree-sha1 = "7c4f882c41faa72118841185afc58a2eb00ef612"
@@ -46,10 +52,10 @@ uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
 version = "0.3.3+0"
 
 [[DataStructures]]
-deps = ["InteractiveUtils", "OrderedCollections"]
-git-tree-sha1 = "edad9434967fdc0a2631a65d902228400642120c"
+deps = ["Compat", "InteractiveUtils", "OrderedCollections"]
+git-tree-sha1 = "0347f23484a96d56e7096eb1f55c6975be34b11a"
 uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
-version = "0.17.19"
+version = "0.18.6"
 
 [[Dates]]
 deps = ["Printf"]
@@ -105,15 +111,15 @@ version = "0.21.0"
 
 [[JSONSchema]]
 deps = ["HTTP", "JSON", "ZipFile"]
-git-tree-sha1 = "832a4d327d9dafdae55a6ecae04f9997c83615cc"
+git-tree-sha1 = "a9ecdbc90be216912a2e3e8a8e38dc4c93f0d065"
 uuid = "7d188eb4-7ad8-530c-ae41-71a32a6d4692"
-version = "0.3.0"
+version = "0.3.2"
 
 [[JuMP]]
-deps = ["Calculus", "DataStructures", "ForwardDiff", "LinearAlgebra", "MathOptInterface", "MutableArithmetics", "NaNMath", "Random", "SparseArrays", "Statistics"]
-git-tree-sha1 = "cbab42e2e912109d27046aa88f02a283a9abac7c"
+deps = ["Calculus", "DataStructures", "ForwardDiff", "JSON", "LinearAlgebra", "MathOptInterface", "MutableArithmetics", "NaNMath", "Random", "SparseArrays", "Statistics"]
+git-tree-sha1 = "57c17a221a55f81890aabf00f478886859e25eaf"
 uuid = "4076af6c-e467-56ae-b986-b466b2749572"
-version = "0.21.3"
+version = "0.21.5"
 
 [[LibGit2]]
 deps = ["Printf"]
@@ -153,9 +159,9 @@ version = "1.0.2"
 
 [[MbedTLS_jll]]
 deps = ["Libdl", "Pkg"]
-git-tree-sha1 = "a0cb0d489819fa7ea5f9fa84c7e7eba19d8073af"
+git-tree-sha1 = "c0b1286883cac4e2b617539de41111e0776d02e8"
 uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
-version = "2.16.6+1"
+version = "2.16.8+0"
 
 [[Mmap]]
 uuid = "a63ad114-7e13-5084-954f-fe012c677804"
@@ -178,15 +184,15 @@ uuid = "efe28fd5-8261-553b-a9e1-b2916fc3738e"
 version = "0.5.3+3"
 
 [[OrderedCollections]]
-git-tree-sha1 = "293b70ac1780f9584c89268a6e2a560d938a7065"
+git-tree-sha1 = "16c08bf5dba06609fe45e30860092d6fa41fde7b"
 uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
-version = "1.3.0"
+version = "1.3.1"
 
 [[Parsers]]
 deps = ["Dates", "Test"]
-git-tree-sha1 = "10134f2ee0b1978ae7752c41306e131a684e1f06"
+git-tree-sha1 = "8077624b3c450b15c087944363606a6ba12f925e"
 uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
-version = "1.0.7"
+version = "1.0.10"
 
 [[Pkg]]
 deps = ["Dates", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
@@ -209,6 +215,10 @@ uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 
 [[Serialization]]
 uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[[SharedArrays]]
+deps = ["Distributed", "Mmap", "Random", "Serialization"]
+uuid = "1a1011a3-84de-559e-8e89-a11a2f7dc383"
 
 [[Sockets]]
 uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
@@ -258,6 +268,6 @@ version = "0.9.2"
 
 [[Zlib_jll]]
 deps = ["Libdl", "Pkg"]
-git-tree-sha1 = "622d8b6dc0c7e8029f17127703de9819134d1b71"
+git-tree-sha1 = "fdd89e5ab270ea0f2a0174bd9093e557d06d4bfa"
 uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
-version = "1.2.11+14"
+version = "1.2.11+16"

--- a/Project.toml
+++ b/Project.toml
@@ -14,9 +14,9 @@ MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
 MutableArithmetics = "d8a4904e-b15c-11e9-3269-09a3773c0cb0"
 
 [compat]
-julia = "1.4"
+HTTP = "0.8"
+JSON = "0.21"
+JuMP = "0.21"
 MathOptInterface = "0.9"
 MutableArithmetics = "0.2"
-JSON = "0.21"
-HTTP = "0.8"
-JuMP = "0.21"
+julia = "1.4"

--- a/Project.toml
+++ b/Project.toml
@@ -11,12 +11,10 @@ JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
-MutableArithmetics = "d8a4904e-b15c-11e9-3269-09a3773c0cb0"
 
 [compat]
 HTTP = "0.8"
 JSON = "0.21"
 JuMP = "0.21"
 MathOptInterface = "0.9"
-MutableArithmetics = "0.2"
 julia = "1.4"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "REoptLite"
 uuid = "0144022d-7626-48b7-867b-06d945449d75"
 authors = ["Nick Laws <nick.laws@nrel.gov>"]
-version = "0.3.0"
+version = "0.4.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/REoptLite.jl
+++ b/src/REoptLite.jl
@@ -34,7 +34,8 @@ export
     REoptInputs,
     run_reopt,
     build_reopt!,
-    reopt_results
+    reopt_results,
+    simulate_outages
 
 import HTTP
 import JSON
@@ -72,4 +73,6 @@ include("constraints/electric_utility_constraints.jl")
 include("constraints/generator_constraints.jl")
 include("core/reopt.jl")
 
-end # module
+include("outagesim/outage_simulator.jl")
+
+end

--- a/src/REoptLite.jl
+++ b/src/REoptLite.jl
@@ -36,7 +36,6 @@ export
     build_reopt!,
     reopt_results
 
-import MutableArithmetics  # TODO can be removed once https://github.com/jump-dev/JuMP.jl/issues/2260 is in release
 import HTTP
 import JSON
 

--- a/src/core/financial.jl
+++ b/src/core/financial.jl
@@ -38,6 +38,6 @@ Base.@kwdef struct Financial
     analysis_years::Int = 25
     macrs_five_year::Array{Float64,1} = [0.2, 0.32, 0.192, 0.1152, 0.1152, 0.0576]  # IRS pub 946
     macrs_seven_year::Array{Float64,1} = [0.1429, 0.2449, 0.1749, 0.1249, 0.0893, 0.0892, 0.0893, 0.0446]
-    VoLL::Union{Array{Real,1}, Real} = 1.00
+    VoLL::Union{Array{R,1}, R} where R<:Real = 1.00
     microgrid_premium_pct::Float64 = 0.3
 end

--- a/src/core/reopt.jl
+++ b/src/core/reopt.jl
@@ -37,6 +37,12 @@ function run_reopt(REopt::JuMP.AbstractModel, fp::String)
 end
 
 
+function run_reopt(REopt::JuMP.AbstractModel, d::Dict)
+	s = Scenario(d)
+	run_reopt(REopt, REoptInputs(s))
+end
+
+
 """
 	function build_reopt!(m::JuMP.AbstractModel, fp::String
 		; lpf::Union{Nothing, JuMP.AbstractModel}=nothing

--- a/src/core/reopt.jl
+++ b/src/core/reopt.jl
@@ -508,7 +508,7 @@ function add_outage_results(m, p, r::Dict)
 	# function to optionally get the outage dispatch values so that we don't slow down returning the
 	# other results.
 	r["expected_outage_cost"] = value(m[:ExpectedOutageCost])
-	r["max_outage_cost_per_outage_duration"] = value.(m[:dvMaxOutageCost])
+	r["max_outage_cost_per_outage_duration"] = value.(m[:dvMaxOutageCost]).data
 	r["total_unserved_load"] = 0
 	for s in p.elecutil.scenarios
 		r["total_unserved_load"] += sum(value.(m[:dvUnservedLoad])[s, tz, ts]

--- a/src/core/reopt.jl
+++ b/src/core/reopt.jl
@@ -502,7 +502,13 @@ function add_generator_results(m, p, r::Dict)
 end
 
 function add_outage_results(m, p, r::Dict)
+	# TODO with many outages the dispatch arrays are so large that it can take hours to create them
+	# (eg. 8760 * 12 hour outages with PV, storage and diesel makes 7*12*8760 = 735,840 values)
+	# For now the outage dispatch outputs are not created (commented out below). Perhaps make a new
+	# function to optionally get the outage dispatch values so that we don't slow down returning the
+	# other results.
 	r["expected_outage_cost"] = value(m[:ExpectedOutageCost])
+	r["max_outage_cost_per_outage_duration"] = value.(m[:dvMaxOutageCost])
 	r["total_unserved_load"] = 0
 	for s in p.elecutil.scenarios
 		r["total_unserved_load"] += sum(value.(m[:dvUnservedLoad])[s, tz, ts]
@@ -513,71 +519,75 @@ function add_outage_results(m, p, r::Dict)
 	r["total_unserved_load"] = round(r["total_unserved_load"], digits=2)
 	r["dvUnservedLoad"] = value.(m[:dvUnservedLoad]).data
 	r["mg_storage_upgrade_cost"] = value(m[:dvMGStorageUpgradeCost])
-	r["dvMGDischargeFromStorage"] = value.(m[:dvMGDischargeFromStorage]).data
+	# r["dvMGDischargeFromStorage"] = value.(m[:dvMGDischargeFromStorage]).data
+
 	if !isempty(p.pvtechs)
 		for t in p.pvtechs
-			# TODO add microgrid dispatch results as well as other MG results
+
 			r[string(t, "mg_kw")] = round(value(m[:dvMGsize][t]), digits=4)
 			r[string("mg_", t, "_upgrade_cost")] = round(value(m[:dvMGTechUpgradeCost][t]), digits=2)
 
-			if !isempty(p.storage.types)
-				PVtoBatt = (m[:dvMGProductionToStorage][t, s, tz, ts] for 
-					s in p.elecutil.scenarios,
-					tz in p.elecutil.outage_start_timesteps,
-					ts in p.elecutil.outage_timesteps)
-			else
-				PVtoBatt = []
-			end
-			r[string("mg", t, "toBatt")] = convert(Array, round.(value.(PVtoBatt), digits=3))
+			# if !isempty(p.storage.types)
+			# 	PVtoBatt = (m[:dvMGProductionToStorage][t, s, tz, ts] for 
+			# 		s in p.elecutil.scenarios,
+			# 		tz in p.elecutil.outage_start_timesteps,
+			# 		ts in p.elecutil.outage_timesteps)
+			# else
+			# 	PVtoBatt = []
+			# end
+			# r[string("mg", t, "toBatt")] = convert(Array, round.(value.(PVtoBatt), digits=3))
 
-			PVtoCUR = (m[:dvMGCurtail][t, s, tz, ts] for 
-				s in p.elecutil.scenarios,
-				tz in p.elecutil.outage_start_timesteps,
-				ts in p.elecutil.outage_timesteps)
-			r[string("mg", t, "toCurtail")] = convert(Array, round.(value.(PVtoCUR), digits=3))
+			# PVtoCUR = (m[:dvMGCurtail][t, s, tz, ts] for 
+			# 	s in p.elecutil.scenarios,
+			# 	tz in p.elecutil.outage_start_timesteps,
+			# 	ts in p.elecutil.outage_timesteps)
+			# r[string("mg", t, "toCurtail")] = convert(Array, round.(value.(PVtoCUR), digits=3))
 
-			PVtoLoad = (
-				m[:dvMGRatedProduction][t, s, tz, ts] * p.production_factor[t, tz+ts] 
-						* p.levelization_factor[t]
-				- m[:dvMGCurtail][t, s, tz, ts]
-				- m[:dvMGProductionToStorage][t, s, tz, ts] for 
-					s in p.elecutil.scenarios,
-					tz in p.elecutil.outage_start_timesteps,
-					ts in p.elecutil.outage_timesteps
-			)
-			r[string("mg", t, "toLoad")] = convert(Array, round.(value.(PVtoLoad), digits=3))
+			# PVtoLoad = (
+			# 	m[:dvMGRatedProduction][t, s, tz, ts] * p.production_factor[t, tz+ts] 
+			# 			* p.levelization_factor[t]
+			# 	- m[:dvMGCurtail][t, s, tz, ts]
+			# 	- m[:dvMGProductionToStorage][t, s, tz, ts] for 
+			# 		s in p.elecutil.scenarios,
+			# 		tz in p.elecutil.outage_start_timesteps,
+			# 		ts in p.elecutil.outage_timesteps
+			# )
+			# r[string("mg", t, "toLoad")] = convert(Array, round.(value.(PVtoLoad), digits=3))
 		end
 	end
+
 	if !isempty(p.gentechs)
 		for t in p.gentechs
+			r[string(t, "_mg_kw")] = round(value(m[:dvMGsize][t]), digits=4)
 			r[string("mg_", t, "_fuel_used")] = value.(m[:dvMGFuelUsed][t, :, :]).data
+			r[string("mg_", t, "_upgrade_cost")] = round(value(m[:dvMGTechUpgradeCost][t]), digits=2)
 
-			if !isempty(p.storage.types)
-				GenToBatt = (m[:dvMGProductionToStorage][t, s, tz, ts] for 
-					s in p.elecutil.scenarios,
-					tz in p.elecutil.outage_start_timesteps,
-					ts in p.elecutil.outage_timesteps)
-			else
-				GenToBatt = []
-			end
-			r[string("mg", t, "toBatt")] = convert(Array, round.(value.(GenToBatt), digits=3))
+			# if !isempty(p.storage.types)
+			# 	GenToBatt = (m[:dvMGProductionToStorage][t, s, tz, ts] for 
+			# 		s in p.elecutil.scenarios,
+			# 		tz in p.elecutil.outage_start_timesteps,
+			# 		ts in p.elecutil.outage_timesteps)
+			# else
+			# 	GenToBatt = []
+			# end
+			# r[string("mg", t, "toBatt")] = convert(Array, round.(value.(GenToBatt), digits=3))
 
-			GENtoCUR = (m[:dvMGCurtail][t, s, tz, ts] for 
-				s in p.elecutil.scenarios,
-				tz in p.elecutil.outage_start_timesteps,
-				ts in p.elecutil.outage_timesteps)
-			r[string("mg", t, "toCurtail")] = convert(Array, round.(value.(GENtoCUR), digits=3))
+			# GENtoCUR = (m[:dvMGCurtail][t, s, tz, ts] for 
+			# 	s in p.elecutil.scenarios,
+			# 	tz in p.elecutil.outage_start_timesteps,
+			# 	ts in p.elecutil.outage_timesteps)
+			# r[string("mg", t, "toCurtail")] = convert(Array, round.(value.(GENtoCUR), digits=3))
 
-			GENtoLoad = (
-				m[:dvMGRatedProduction][t, s, tz, ts] * p.production_factor[t, tz+ts] 
-						* p.levelization_factor[t]
-				- m[:dvMGCurtail][t, s, tz, ts]
-				- m[:dvMGProductionToStorage][t, s, tz, ts] for 
-					s in p.elecutil.scenarios,
-					tz in p.elecutil.outage_start_timesteps,
-					ts in p.elecutil.outage_timesteps
-			)
-			r[string("mg", t, "toLoad")] = convert(Array, round.(value.(GENtoLoad), digits=3))
+			# GENtoLoad = (
+			# 	m[:dvMGRatedProduction][t, s, tz, ts] * p.production_factor[t, tz+ts] 
+			# 			* p.levelization_factor[t]
+			# 	- m[:dvMGCurtail][t, s, tz, ts]
+			# 	- m[:dvMGProductionToStorage][t, s, tz, ts] for 
+			# 		s in p.elecutil.scenarios,
+			# 		tz in p.elecutil.outage_start_timesteps,
+			# 		ts in p.elecutil.outage_timesteps
+			# )
+			# r[string("mg", t, "toLoad")] = convert(Array, round.(value.(GENtoLoad), digits=3))
 		end
 	end
 end

--- a/src/core/reopt_inputs.jl
+++ b/src/core/reopt_inputs.jl
@@ -52,7 +52,7 @@ struct REoptInputs
     months::UnitRange
     production_factor::DenseAxisArray{Float64, 2}  # (techs, time_steps)
     levelization_factor::DenseAxisArray{Float64, 1}  # (techs)
-    VoLL::Array{Real, 1} #default set to 1 US dollar per kwh
+    VoLL::Array{R, 1} where R<:Real #default set to 1 US dollar per kwh
     pwf_e::Float64
     pwf_om::Float64
     two_party_factor::Float64
@@ -126,7 +126,7 @@ function REoptInputs(s::Scenario)
         months,
         production_factor,
         levelization_factor,
-        typeof(s.financial.VoLL) == Array{Real, 1} ? s.financial.VoLL : fill(s.financial.VoLL, length(time_steps)),
+        typeof(s.financial.VoLL) <: Array{<:Real, 1} ? s.financial.VoLL : fill(s.financial.VoLL, length(time_steps)),
         pwf_e,
         pwf_om,
         two_party_factor,

--- a/src/core/utils.jl
+++ b/src/core/utils.jl
@@ -167,9 +167,6 @@ function filter_dict_to_match_struct_field_names(d::Dict, s::DataType)
 end
 
 
-JuMP.value(x::Number) = x  # for @expression(REopt, ExportBenefitYr1, 0) and similar
-JuMP.value(::MutableArithmetics.Zero) = 0
-
 function npv(rate::Float64, cash_flows::Array)
     npv = cash_flows[1]
     for (y, c) in enumerate(cash_flows[2:end])
@@ -177,4 +174,3 @@ function npv(rate::Float64, cash_flows::Array)
     end
     return npv
 end
-

--- a/src/outagesim/outage_simulator.jl
+++ b/src/outagesim/outage_simulator.jl
@@ -1,0 +1,215 @@
+# *********************************************************************************
+# REopt, Copyright (c) 2019-2020, Alliance for Sustainable Energy, LLC.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met
+#
+# Redistributions of source code must retain the above copyright notice, this list
+# of conditions and the following disclaimer.
+#
+# Redistributions in binary form must reproduce the above copyright notice, this
+# list of conditions and the following disclaimer in the documentation and/or other
+# materials provided with the distribution.
+#
+# Neither the name of the copyright holder nor the names of its contributors may be
+# used to endorse or promote products derived from this software without specific
+# prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+# IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+# OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+# OF THE POSSIBILITY OF SUCH DAMAGE.
+# *********************************************************************************
+
+
+function simulate_outage(;init_time_step, diesel_kw, fuel_available, b, m, diesel_min_turndown, batt_kwh, batt_kw,
+                    batt_roundtrip_efficiency, n_timesteps, n_steps_per_hour, batt_soc_kwh, crit_load)
+    """
+    Determine how long the critical load can be met with gas generator and energy storage.
+    :param init_time_step: Int, initial time step
+    :param diesel_kw: float, generator capacity
+    :param fuel_available: float, gallons
+    :param b: float, diesel fuel burn rate intercept coefficient (y = m*x + b)  [gal/hr]
+    :param m: float, diesel fuel burn rate slope (y = m*x + b)  [gal/kWh]
+    :param diesel_min_turndown:
+    :param batt_kwh: float, battery capacity
+    :param batt_kw: float, battery inverter capacity (AC rating)
+    :param batt_roundtrip_efficiency:
+    :param batt_soc_kwh: float, battery state of charge in kWh
+    :param n_timesteps: Int, number of time steps in a year
+    :param n_steps_per_hour: Int, number of time steps per hour
+    :param crit_load: list of float, load after DER (PV, Wind, ...)
+    :return: float, number of hours that the critical load can be met using load following
+    """
+    for i in 0:n_timesteps-1
+        t = (init_time_step - 1 + i) % n_timesteps + 1  # for wrapping around end of year
+        load_kw = crit_load[t]
+
+        if load_kw < 0  # load is met
+            if batt_soc_kwh < batt_kwh  # charge battery if there's room in the battery
+                batt_soc_kwh += minimum([
+                    batt_kwh - batt_soc_kwh,     # room available
+                    batt_kw / n_steps_per_hour * batt_roundtrip_efficiency,  # inverter capacity
+                    -load_kw / n_steps_per_hour * batt_roundtrip_efficiency,  # excess energy
+                ])
+            end
+
+        else  # check if we can meet load with generator then storage
+            fuel_needed = (m * maximum([load_kw, diesel_min_turndown * diesel_kw]) + b) / n_steps_per_hour
+            # (gal/kWh * kW + gal/hr) * hr = gal
+            if load_kw <= diesel_kw && fuel_needed <= fuel_available  # diesel can meet load
+                fuel_available -= fuel_needed
+                if load_kw < diesel_min_turndown * diesel_kw  # extra generation goes to battery
+                    if batt_soc_kwh < batt_kwh  # charge battery if there's room in the battery
+                        batt_soc_kwh += minimum([
+                            batt_kwh - batt_soc_kwh,     # room available
+                            batt_kw / n_steps_per_hour * batt_roundtrip_efficiency,  # inverter capacity
+                            (diesel_min_turndown * diesel_kw - load_kw) / n_steps_per_hour * batt_roundtrip_efficiency  # excess energy
+                        ])
+                    end
+                end
+                load_kw = 0
+
+            else  # diesel can meet part or no load
+                if fuel_needed > fuel_available && load_kw <= diesel_kw  # tank is limiting factor
+                    load_kw -= maximum([0, (fuel_available * n_steps_per_hour - b) / m])  # (gal/hr - gal/hr) * kWh/gal = kW
+                    fuel_available = 0
+
+                elseif fuel_needed <= fuel_available && load_kw > diesel_kw  # diesel capacity is limiting factor
+                    load_kw -= diesel_kw
+                    # run diesel gen at max output
+                    fuel_available = maximum([0, fuel_available - (diesel_kw * m + b) / n_steps_per_hour])
+                                                                # (kW * gal/kWh + gal/hr) * hr = gal
+                else  # fuel_needed > fuel_available && load_kw > diesel_kw  # limited by fuel and diesel capacity
+                    # run diesel at full capacity and drain tank
+                    load_kw -= minimum([diesel_kw, maximum([0, (fuel_available * n_steps_per_hour - b) / m])])
+                    fuel_available = 0
+                end
+
+                if minimum([batt_kw, batt_soc_kwh * n_steps_per_hour]) >= load_kw  # battery can carry balance
+                    # prevent battery charge from going negative
+                    batt_soc_kwh = maximum([0, batt_soc_kwh - load_kw / n_steps_per_hour])
+                    load_kw = 0
+                end
+            end
+        end
+
+        if round(load_kw, digits=5) > 0  # failed to meet load in this time step
+            return i / n_steps_per_hour
+        end
+    end
+
+    return n_timesteps / n_steps_per_hour  # met the critical load for all time steps
+end
+
+
+function simulate_outages(;batt_kwh=0, batt_kw=0, pv_kw_ac_hourly=[], init_soc=0, critical_loads_kw=[], wind_kw_ac_hourly=[],
+                     batt_roundtrip_efficiency=0.829, diesel_kw=0, fuel_available=0, b=0, m=0, diesel_min_turndown=0.3,
+                     )
+    """
+    :param batt_kwh: float, battery storage capacity
+    :param batt_kw: float, battery inverter capacity
+    :param pv_kw_ac_hourly: list of floats, AC production of PV system
+    :param init_soc: list of floats between 0 and 1 inclusive, initial state-of-charge
+    :param critical_loads_kw: list of floats
+    :param wind_kw_ac_hourly: list of floats, AC production of wind turbine
+    :param batt_roundtrip_efficiency: roundtrip battery efficiency
+    :param diesel_kw: float, diesel generator capacity
+    :param fuel_available: float, gallons of diesel fuel available
+    :param b: float, diesel fuel burn rate intercept coefficient (y = m*x + b*rated_capacity)  [gal/kwh/kw]
+    :param m: float, diesel fuel burn rate slope (y = m*x + b*rated_capacity)  [gal/kWh]
+    :param diesel_min_turndown: minimum generator turndown in fraction of generator capacity (0 to 1)
+    :return: dict,
+        {
+            "resilience_by_timestep": r,
+            "resilience_hours_min": r_min,
+            "resilience_hours_max": r_max,
+            "resilience_hours_avg": r_avg,
+            "outage_durations": x_vals,
+            "probs_of_surviving": y_vals,
+            "probs_of_surviving_by_month": y_vals_group_month,
+            "probs_of_surviving_by_hour_of_the_day": y_vals_group_hour,
+        }
+    """
+    n_timesteps = length(critical_loads_kw)
+    n_steps_per_hour = Int(n_timesteps / 8760)
+    r = repeat([0], n_timesteps)
+
+    if batt_kw == 0 || batt_kwh == 0
+        init_soc = repeat([0], n_timesteps)  # default is 0
+
+        if (isempty(pv_kw_ac_hourly) || (sum(pv_kw_ac_hourly) == 0)) && diesel_kw == 0
+            # no pv, generator, nor battery --> no resilience
+            return Dict(
+                "resilience_by_timestep" => r,
+                "resilience_hours_min" => 0,
+                "resilience_hours_max" => 0,
+                "resilience_hours_avg" => 0,
+                "outage_durations" => [],
+                "probs_of_surviving" => [],
+            )
+        end
+    end
+
+    if isempty(pv_kw_ac_hourly)
+        pv_kw_ac_hourly = repeat([0], n_timesteps)
+    end
+    if isempty(wind_kw_ac_hourly)
+        wind_kw_ac_hourly = repeat([0], n_timesteps)
+    end
+    load_minus_der = [ld - pv - wd for (pv, wd, ld) in zip(pv_kw_ac_hourly, wind_kw_ac_hourly, critical_loads_kw)]
+    """
+    Simulation starts here
+    """
+    # outer loop: do simulation starting at each time step
+    
+    for time_step in 1:n_timesteps
+        r[time_step] = simulate_outage(;
+            init_time_step=time_step,
+            diesel_kw=diesel_kw,
+            fuel_available=fuel_available,
+            b=b, m=m,
+            diesel_min_turndown=diesel_min_turndown,
+            batt_kwh=batt_kwh,
+            batt_kw=batt_kw,
+            batt_roundtrip_efficiency=batt_roundtrip_efficiency,
+            n_timesteps=n_timesteps,
+            n_steps_per_hour=n_steps_per_hour,
+            batt_soc_kwh=init_soc[time_step] * batt_kwh,
+            crit_load=load_minus_der
+        )
+    end
+    results = process_results(r, n_timesteps)
+    return results
+end
+
+
+function process_results(r, n_timesteps)
+
+    r_min = minimum(r)
+    r_max = maximum(r)
+    r_avg = round((float(sum(r)) / float(length(r))), digits=2)
+
+    x_vals = collect(range(1, stop=Int(floor(r_max)+1)))
+    y_vals = Array{Float64, 1}()
+
+    for hrs in x_vals
+        push!(y_vals, round(sum([h >= hrs ? 1 : 0 for h in r]) / n_timesteps, 
+                            digits=4))
+    end
+    return Dict(
+        "resilience_by_timestep" => r,
+        "resilience_hours_min" => r_min,
+        "resilience_hours_max" => r_max,
+        "resilience_hours_avg" => r_avg,
+        "outage_durations" => x_vals,
+        "probs_of_surviving" => y_vals,
+    )
+end

--- a/test/Manifest.toml
+++ b/test/Manifest.toml
@@ -17,9 +17,9 @@ version = "0.5.10"
 
 [[Bzip2_jll]]
 deps = ["Libdl", "Pkg"]
-git-tree-sha1 = "3663bfffede2ef41358b6fc2e1d8a6d50b3c3904"
+git-tree-sha1 = "03a44490020826950c68005cafb336e5ba08b7e8"
 uuid = "6e34b625-4abd-537c-b88f-471c36dfa7a0"
-version = "1.0.6+2"
+version = "1.0.6+4"
 
 [[CEnum]]
 git-tree-sha1 = "1b77a77c3b28e0b3f413f7567c9bb8dd9bdccd14"
@@ -58,9 +58,9 @@ version = "0.60.2+5"
 
 [[Clp_jll]]
 deps = ["CoinUtils_jll", "CompilerSupportLibraries_jll", "Libdl", "OpenBLAS32_jll", "Osi_jll", "Pkg"]
-git-tree-sha1 = "70fe9e52fd95fa37f645e3d30f08f436cc5b1457"
+git-tree-sha1 = "79263d9383ca89b35f31c33ab5b880536a8413a4"
 uuid = "06985876-5285-5a41-9fcb-8948a742cc53"
-version = "1.17.6+5"
+version = "1.17.6+6"
 
 [[CodecBzip2]]
 deps = ["Bzip2_jll", "Libdl", "TranscodingStreams"]
@@ -86,6 +86,12 @@ git-tree-sha1 = "7b8a93dba8af7e3b42fecabf646260105ac373f7"
 uuid = "bbf7d656-a473-5ed7-a52c-81e309532950"
 version = "0.3.0"
 
+[[Compat]]
+deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "SHA", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Statistics", "Test", "UUIDs", "Unicode"]
+git-tree-sha1 = "7c7f4cda0d58ec999189d70f5ee500348c4b4df1"
+uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
+version = "3.16.0"
+
 [[CompilerSupportLibraries_jll]]
 deps = ["Libdl", "Pkg"]
 git-tree-sha1 = "7c4f882c41faa72118841185afc58a2eb00ef612"
@@ -93,14 +99,18 @@ uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
 version = "0.3.3+0"
 
 [[DataStructures]]
-deps = ["InteractiveUtils", "OrderedCollections"]
-git-tree-sha1 = "edad9434967fdc0a2631a65d902228400642120c"
+deps = ["Compat", "InteractiveUtils", "OrderedCollections"]
+git-tree-sha1 = "0347f23484a96d56e7096eb1f55c6975be34b11a"
 uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
-version = "0.17.19"
+version = "0.18.6"
 
 [[Dates]]
 deps = ["Printf"]
 uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+
+[[DelimitedFiles]]
+deps = ["Mmap"]
+uuid = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 
 [[DiffResults]]
 deps = ["StaticArrays"]
@@ -126,9 +136,9 @@ version = "0.10.12"
 
 [[HTTP]]
 deps = ["Base64", "Dates", "IniFile", "MbedTLS", "Sockets"]
-git-tree-sha1 = "eca61b35cdd8cd2fcc5eec1eda766424a995b02f"
+git-tree-sha1 = "c7ec02c4c6a039a98a15f955462cd7aea5df4508"
 uuid = "cd3eb016-35fb-5094-929b-558a96fad6f3"
-version = "0.8.16"
+version = "0.8.19"
 
 [[IniFile]]
 deps = ["Test"]
@@ -148,15 +158,15 @@ version = "0.21.0"
 
 [[JSONSchema]]
 deps = ["HTTP", "JSON", "ZipFile"]
-git-tree-sha1 = "832a4d327d9dafdae55a6ecae04f9997c83615cc"
+git-tree-sha1 = "a9ecdbc90be216912a2e3e8a8e38dc4c93f0d065"
 uuid = "7d188eb4-7ad8-530c-ae41-71a32a6d4692"
-version = "0.3.0"
+version = "0.3.2"
 
 [[JuMP]]
-deps = ["Calculus", "DataStructures", "ForwardDiff", "LinearAlgebra", "MathOptInterface", "MutableArithmetics", "NaNMath", "Random", "SparseArrays", "Statistics"]
-git-tree-sha1 = "cbab42e2e912109d27046aa88f02a283a9abac7c"
+deps = ["Calculus", "DataStructures", "ForwardDiff", "JSON", "LinearAlgebra", "MathOptInterface", "MutableArithmetics", "NaNMath", "Random", "SparseArrays", "Statistics"]
+git-tree-sha1 = "57c17a221a55f81890aabf00f478886859e25eaf"
 uuid = "4076af6c-e467-56ae-b986-b466b2749572"
-version = "0.21.3"
+version = "0.21.5"
 
 [[LibGit2]]
 deps = ["Printf"]
@@ -184,9 +194,9 @@ uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
 
 [[MathOptInterface]]
 deps = ["BenchmarkTools", "CodecBzip2", "CodecZlib", "JSON", "JSONSchema", "LinearAlgebra", "MutableArithmetics", "OrderedCollections", "SparseArrays", "Test", "Unicode"]
-git-tree-sha1 = "cd2049c055c7d192a235670d50faa375361624ba"
+git-tree-sha1 = "5a1d631e0a9087d425e024d66b9c71e92e78fda8"
 uuid = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
-version = "0.9.14"
+version = "0.9.17"
 
 [[MathProgBase]]
 deps = ["LinearAlgebra", "SparseArrays"]
@@ -202,9 +212,9 @@ version = "1.0.2"
 
 [[MbedTLS_jll]]
 deps = ["Libdl", "Pkg"]
-git-tree-sha1 = "a0cb0d489819fa7ea5f9fa84c7e7eba19d8073af"
+git-tree-sha1 = "c0b1286883cac4e2b617539de41111e0776d02e8"
 uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
-version = "2.16.6+1"
+version = "2.16.8+0"
 
 [[Mmap]]
 uuid = "a63ad114-7e13-5084-954f-fe012c677804"
@@ -233,9 +243,9 @@ uuid = "efe28fd5-8261-553b-a9e1-b2916fc3738e"
 version = "0.5.3+3"
 
 [[OrderedCollections]]
-git-tree-sha1 = "293b70ac1780f9584c89268a6e2a560d938a7065"
+git-tree-sha1 = "16c08bf5dba06609fe45e30860092d6fa41fde7b"
 uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
-version = "1.3.0"
+version = "1.3.1"
 
 [[Osi_jll]]
 deps = ["CoinUtils_jll", "CompilerSupportLibraries_jll", "Libdl", "OpenBLAS32_jll", "Pkg"]
@@ -245,9 +255,9 @@ version = "0.108.5+3"
 
 [[Parsers]]
 deps = ["Dates", "Test"]
-git-tree-sha1 = "10134f2ee0b1978ae7752c41306e131a684e1f06"
+git-tree-sha1 = "8077624b3c450b15c087944363606a6ba12f925e"
 uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
-version = "1.0.7"
+version = "1.0.10"
 
 [[Pkg]]
 deps = ["Dates", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
@@ -270,6 +280,10 @@ uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 
 [[Serialization]]
 uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[[SharedArrays]]
+deps = ["Distributed", "Mmap", "Random", "Serialization"]
+uuid = "1a1011a3-84de-559e-8e89-a11a2f7dc383"
 
 [[Sockets]]
 uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
@@ -325,6 +339,6 @@ version = "0.9.2"
 
 [[Zlib_jll]]
 deps = ["Libdl", "Pkg"]
-git-tree-sha1 = "622d8b6dc0c7e8029f17127703de9819134d1b71"
+git-tree-sha1 = "fdd89e5ab270ea0f2a0174bd9093e557d06d4bfa"
 uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
-version = "1.2.11+14"
+version = "1.2.11+16"

--- a/test/scenarios/nogridcost_minresilhours.json
+++ b/test/scenarios/nogridcost_minresilhours.json
@@ -62,6 +62,6 @@
   "Generator": {
   },
   "Financial": {
-    "VoLL": 0.0
+    "VoLL": 0.001
   }
 }

--- a/test/test_with_cplex.jl
+++ b/test/test_with_cplex.jl
@@ -88,7 +88,7 @@ end
     - should meet 168 kWh in each outage such that the total unserved load is 12 kWh
     =#
     m = Model(optimizer_with_attributes(CPLEX.Optimizer, "CPX_PARAM_SCRIND" => 0))
-    results = run_reopt(m, ".test/scenarios/nogridcost_minresilhours.json")
+    results = run_reopt(m, "./scenarios/nogridcost_minresilhours.json")
     @test results["total_unserved_load"] ≈ 12
 end
 


### PR DESCRIPTION
## v0.4.0
#### Improvements
- add `simulate_outages` function (similar to REopt Lite API outage simulator)
- removed MutableArithmetics package from Project.toml (since JuMP now has method for `value(::MutableArithmetics.Zero)`)
- added outage related outputs:
    - Generator_mg_kw
    - mg_Generator_upgrade_cost
    - mg_Generator_fuel_used
    - mg_PV_upgrade_cost
    - mg_storage_upgrade_cost
    - dvUnservedLoad array
    - max_outage_cost_per_outage_duration
- allow VoLL values to be subtype of Real (rather than only Real)
- add `run_reopt` method for scenario Dict