### PR TITLE
add LinDistFlow modeling, rm storage export 

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -21,6 +21,12 @@ git-tree-sha1 = "c3598e525718abcc440f69cc6d5f60dda0a1b61e"
 uuid = "6e34b625-4abd-537c-b88f-471c36dfa7a0"
 version = "1.0.6+5"
 
+[[CSV]]
+deps = ["Dates", "Mmap", "Parsers", "PooledArrays", "SentinelArrays", "Tables", "Unicode"]
+git-tree-sha1 = "6d4242ef4cb1539e7ede8e01a47a32365e0a34cd"
+uuid = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
+version = "0.8.4"
+
 [[Calculus]]
 deps = ["LinearAlgebra"]
 git-tree-sha1 = "f641eb0a4f00c343bbc32346e1217b86f3ce9dad"
@@ -63,11 +69,21 @@ git-tree-sha1 = "8e695f735fca77e9708e795eda62afdb869cbb70"
 uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
 version = "0.3.4+0"
 
+[[DataAPI]]
+git-tree-sha1 = "dfb3b7e89e395be1e25c2ad6d7690dc29cc53b1d"
+uuid = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"
+version = "1.6.0"
+
 [[DataStructures]]
 deps = ["Compat", "InteractiveUtils", "OrderedCollections"]
 git-tree-sha1 = "4437b64df1e0adccc3e5d1adbc3ac741095e4677"
 uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 version = "0.18.9"
+
+[[DataValueInterfaces]]
+git-tree-sha1 = "bfc1187b79289637fa0ef6d4436ebdfe6905cbd6"
+uuid = "e2d170a0-9d28-54be-80f0-106bbe20a464"
+version = "1.0.0"
 
 [[Dates]]
 deps = ["Printf"]
@@ -99,6 +115,10 @@ git-tree-sha1 = "d48a40c0f54f29a5c8748cfb3225719accc72b77"
 uuid = "f6369f11-7733-5829-9624-2563aa707210"
 version = "0.10.16"
 
+[[Future]]
+deps = ["Random"]
+uuid = "9fa8497b-333b-5362-9e8d-4d0656e87820"
+
 [[HTTP]]
 deps = ["Base64", "Dates", "IniFile", "MbedTLS", "Sockets"]
 git-tree-sha1 = "c7ec02c4c6a039a98a15f955462cd7aea5df4508"
@@ -114,6 +134,11 @@ version = "0.5.0"
 [[InteractiveUtils]]
 deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+
+[[IteratorInterfaceExtensions]]
+git-tree-sha1 = "a3f24677c21f5bbe9d2a714f95dcd58337fb2856"
+uuid = "82899510-4779-5014-852e-03e436cf321d"
+version = "1.0.0"
 
 [[JLLWrappers]]
 git-tree-sha1 = "a431f5f2ca3f4feef3bd7a5e94b8b8d4f2f647a0"
@@ -144,6 +169,12 @@ uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
 
 [[Libdl]]
 uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
+[[LinDistFlow]]
+deps = ["CSV", "JuMP", "LinearAlgebra", "Logging", "SparseArrays"]
+git-tree-sha1 = "cb2a494176d060f0ceb768c9a96d26c9c4f8c3e3"
+uuid = "bf674bac-ffe4-48d3-9f32-72124ffa9ede"
+version = "0.1.0"
 
 [[LinearAlgebra]]
 deps = ["Libdl"]
@@ -215,6 +246,12 @@ version = "1.0.15"
 deps = ["Dates", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 
+[[PooledArrays]]
+deps = ["DataAPI", "Future"]
+git-tree-sha1 = "cde4ce9d6f33219465b55162811d8de8139c0414"
+uuid = "2dfb63ee-cc39-5dd5-95bd-886bf059d720"
+version = "1.2.1"
+
 [[Printf]]
 deps = ["Unicode"]
 uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
@@ -229,6 +266,12 @@ uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [[SHA]]
 uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+
+[[SentinelArrays]]
+deps = ["Dates", "Random"]
+git-tree-sha1 = "6ccde405cf0759eba835eb613130723cb8f10ff9"
+uuid = "91c51154-3ec4-41a3-a24f-3f23e20d615c"
+version = "1.2.16"
 
 [[Serialization]]
 uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
@@ -259,6 +302,18 @@ version = "1.0.1"
 [[Statistics]]
 deps = ["LinearAlgebra", "SparseArrays"]
 uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+
+[[TableTraits]]
+deps = ["IteratorInterfaceExtensions"]
+git-tree-sha1 = "b1ad568ba658d8cbb3b892ed5380a6f3e781a81e"
+uuid = "3783bdb8-4a98-5b6b-af9a-565f29a5fe9c"
+version = "1.0.0"
+
+[[Tables]]
+deps = ["DataAPI", "DataValueInterfaces", "IteratorInterfaceExtensions", "LinearAlgebra", "TableTraits", "Test"]
+git-tree-sha1 = "f03fc113290ee7726b173fc7ea661260d204b3f2"
+uuid = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
+version = "1.4.0"
 
 [[Test]]
 deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]

--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,7 @@ DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
+LinDistFlow = "bf674bac-ffe4-48d3-9f32-72124ffa9ede"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
 

--- a/src/REoptLite.jl
+++ b/src/REoptLite.jl
@@ -36,6 +36,7 @@ export
     build_reopt!,
     reopt_results,
     simulate_outages,
+    add_variables!,
     # for docs:
     ElectricLoad,
     Financial,

--- a/src/REoptLite.jl
+++ b/src/REoptLite.jl
@@ -44,6 +44,8 @@ export
 
 import HTTP
 import JSON
+import LinDistFlow 
+const LDF = LinDistFlow
 using JuMP
 using JuMP.Containers: DenseAxisArray
 using Logging

--- a/src/REoptLite.jl
+++ b/src/REoptLite.jl
@@ -47,6 +47,7 @@ export
 
 import HTTP
 import JSON
+using LinDistFlow  # required to export LinDistFlow
 import LinDistFlow 
 const LDF = LinDistFlow
 using JuMP

--- a/src/REoptLite.jl
+++ b/src/REoptLite.jl
@@ -37,6 +37,8 @@ export
     reopt_results,
     simulate_outages,
     add_variables!,
+    add_objective!,
+    LinDistFlow,
     # for docs:
     ElectricLoad,
     Financial,
@@ -93,5 +95,7 @@ include("core/reopt.jl")
 include("core/reopt_multinode.jl")
 
 include("outagesim/outage_simulator.jl")
+
+include("lindistflow/extend.jl")
 
 end

--- a/src/constraints/electric_utility_constraints.jl
+++ b/src/constraints/electric_utility_constraints.jl
@@ -38,8 +38,7 @@ function add_export_constraints(m, p; _n="")
     ##Constraint (8f): Total sales to grid no greater than annual allocation - storage tiers
     @constraint(m,
         p.hours_per_timestep * ( 
-        sum( m[Symbol("dvStorageExport"*_n)][b,u,ts] for b in p.storage.types, u in p.storage.export_bins, ts in p.time_steps_with_grid if !(u in p.etariff.curtail_bins)) 
-        + sum( m[Symbol("dvWHLexport"*_n)][t, ts] for t in p.techs, ts in p.time_steps_with_grid)
+        sum( m[Symbol("dvWHLexport"*_n)][t, ts] for t in p.techs, ts in p.time_steps_with_grid)
         + sum( m[Symbol("dvNEMexport"*_n)][t, ts] for t in p.techs, ts in p.time_steps_with_grid)
         ) <= p.max_grid_export_kwh
     )
@@ -50,7 +49,6 @@ function add_export_constraints(m, p; _n="")
     @constraint(m,
         p.hours_per_timestep * ( 
         sum( m[Symbol("dvNEMexport"*_n)][t, ts] for t in p.techs, ts in p.time_steps)
-        + sum( m[Symbol("dvStorageExport"*_n)][b, u, ts] for b in p.storage.types, u in p.storage.export_bins, ts in p.time_steps)
         ) <= p.hours_per_timestep * sum( m[Symbol("dvGridPurchase"*_n)][ts] for ts in p.time_steps)
     )
 end

--- a/src/constraints/load_balance.jl
+++ b/src/constraints/load_balance.jl
@@ -31,7 +31,7 @@
 function add_load_balance_constraints(m, p; _n="") 
 
 	##Constraint (8a): Electrical Load Balancing with Grid
-	@constraint(m, [ts in p.time_steps_with_grid],
+	conrefs = @constraint(m, [ts in p.time_steps_with_grid],
 		sum(p.production_factor[t, ts] * p.levelization_factor[t] * m[Symbol("dvRatedProduction"*_n)][t,ts] for t in p.elec_techs) +  
 		sum( m[Symbol("dvDischargeFromStorage"*_n)][b,ts] for b in p.storage.types ) + 
 		m[Symbol("dvGridPurchase"*_n)][ts] ==
@@ -41,6 +41,10 @@ function add_load_balance_constraints(m, p; _n="")
 		+ sum(m[Symbol("dvGridToStorage"*_n)][b, ts] for b in p.storage.types)
 		+ p.elec_load.loads_kw[ts]
 	)
+
+	for (i, cr) in enumerate(conrefs)
+		JuMP.set_name(cr, "con_load_balance"*_n*string("_t", i))
+	end
 	
 	##Constraint (8b): Electrical Load Balancing without Grid
 	@constraint(m, [ts in p.time_steps_without_grid],

--- a/src/constraints/load_balance.jl
+++ b/src/constraints/load_balance.jl
@@ -37,7 +37,6 @@ function add_load_balance_constraints(m, p; _n="")
 		m[Symbol("dvGridPurchase"*_n)][ts] ==
 		sum( sum(m[Symbol("dvProductionToStorage"*_n)][b, t, ts] for b in p.storage.types) 
 			+ m[Symbol("dvWHLexport"*_n)][t, ts] + m[Symbol("dvNEMexport"*_n)][t, ts] + m[Symbol("dvCurtail"*_n)][t, ts] for t in p.elec_techs)
-		+ sum(m[Symbol("dvStorageExport"*_n)][b, u, ts] for b in p.storage.types, u in p.storage.export_bins) 
 		+ sum(m[Symbol("dvGridToStorage"*_n)][b, ts] for b in p.storage.types)
 		+ p.elec_load.loads_kw[ts]
 	)

--- a/src/constraints/storage_constraints.jl
+++ b/src/constraints/storage_constraints.jl
@@ -122,10 +122,4 @@ function add_storage_sum_constraints(m, p; _n="")
 	@constraint(m, [ts in p.time_steps_with_grid],
         m[Symbol("dvGridPurchase"*_n)][ts] >= sum(m[Symbol("dvGridToStorage"*_n)][b, ts] for b in p.storage.types)
     )
-
-	##Constraint (8d): Storage export no greater than discharge from Storage
-	@constraint(m, [ts in p.time_steps_with_grid],
-        sum(m[Symbol("dvDischargeFromStorage"*_n)][b,ts] for b in p.storage.types)  >= 
-            sum(m[Symbol("dvStorageExport"*_n)][b, u, ts] for b in p.storage.types, u in p.storage.export_bins)
-    )
 end

--- a/src/core/reopt.jl
+++ b/src/core/reopt.jl
@@ -96,8 +96,6 @@ function build_reopt!(m::JuMP.AbstractModel, p::REoptInputs)
 						m[:dvProductionToStorage][b, t, ts] == 0)
 			@constraint(m, [ts in p.time_steps], m[:dvDischargeFromStorage][b, ts] == 0)
 			@constraint(m, [ts in p.time_steps], m[:dvGridToStorage][b, ts] == 0)
-			@constraint(m, [u in p.storage.export_bins, ts in p.time_steps],
-						m[:dvStorageExport][b, u, ts] == 0)
 		else
 			add_storage_size_constraints(m, p, b)
 			add_storage_dispatch_constraints(m, p, b)
@@ -164,8 +162,7 @@ function build_reopt!(m::JuMP.AbstractModel, p::REoptInputs)
 	if !isempty(p.techs)
 		# NOTE: levelization_factor is baked into dvNEMexport, dvWHLexport
 		@expression(m, TotalExportBenefit, p.pwf_e * p.hours_per_timestep * sum(
-			sum( p.etariff.export_rates[u][ts] * m[:dvStorageExport][b,u,ts] for b in p.storage.can_grid_charge, u in p.storage.export_bins)
-		  + sum( p.etariff.export_rates[:NEM][ts] * m[:dvNEMexport][t, ts] for t in p.techs)
+			sum( p.etariff.export_rates[:NEM][ts] * m[:dvNEMexport][t, ts] for t in p.techs)
 		  + sum( p.etariff.export_rates[:WHL][ts] * m[:dvWHLexport][t, ts]  for t in p.techs)
 			for ts in p.time_steps )
 		)
@@ -306,7 +303,6 @@ function add_variables!(m::JuMP.AbstractModel, p::REoptInputs)
 		dvStoredEnergy[p.storage.types, 0:p.time_steps[end]] >= 0  # State of charge of storage system b
 		dvStoragePower[p.storage.types] >= 0   # Power capacity of storage system b [kW]
 		dvStorageEnergy[p.storage.types] >= 0   # Energy capacity of storage system b [kWh]
-		dvStorageExport[p.storage.types, p.storage.export_bins, p.time_steps] >= 0  # storage to the grid or curtail [kW]
 		dvPeakDemandTOU[p.ratchets] >= 0  # Peak electrical power demand during ratchet r [kW]
 		dvPeakDemandMonth[p.months] >= 0  # Peak electrical power demand during month m [kW]
 		MinChargeAdder >= 0

--- a/src/core/reopt_multinode.jl
+++ b/src/core/reopt_multinode.jl
@@ -318,7 +318,6 @@ function run_reopt(m::JuMP.AbstractModel, ps::Array{REoptInputs}; obj::Int=2)
 	time_elapsed = time() - tstart
 	@info "Total results processing took $(round(time_elapsed, digits=3)) seconds."
 	results["status"] = status
-	results["inputs"] = ps
 	return results
 end
 

--- a/src/core/reopt_multinode.jl
+++ b/src/core/reopt_multinode.jl
@@ -119,11 +119,6 @@ function add_variables!(m::JuMP.AbstractModel, ps::Array{REoptInputs})
                 sum( p.etariff.export_rates[:NEM][ts] * m[Symbol("dvNEMexport"*_n)][t, ts] for t in p.techs)
               + sum( p.etariff.export_rates[:WHL][ts] * m[Symbol("dvWHLexport"*_n)][t, ts]  for t in p.techs)
                 for ts in p.time_steps )
-            if !isempty(p.storage.export_bins)
-                m[Symbol("TotalExportBenefit"*_n)] += p.pwf_e * p.hours_per_timestep *
-                sum( p.etariff.export_rates[u][ts] * m[Symbol("dvStorageExport"*_n)][b,u,ts] 
-                     for b in p.storage.can_grid_charge, u in p.storage.export_bins)
-            end
         else
             m[Symbol("TotalExportBenefit"*_n)] = 0
         end
@@ -243,8 +238,6 @@ function build_reopt!(m::JuMP.AbstractModel, ps::Array{REoptInputs})
                             m[Symbol("dvProductionToStorage"*_n)][b, t, ts] == 0)
                 @constraint(m, [ts in p.time_steps], m[Symbol("dvDischargeFromStorage"*_n)][b, ts] == 0)
                 @constraint(m, [ts in p.time_steps], m[Symbol("dvGridToStorage"*_n)][b, ts] == 0)
-                @constraint(m, [u in p.storage.export_bins, ts in p.time_steps],
-                            m[Symbol("dvStorageExport"*_n)][b, u, ts] == 0)
             else
                 add_storage_size_constraints(m, p, b; _n=_n)
                 add_storage_dispatch_constraints(m, p, b; _n=_n)

--- a/src/core/site.jl
+++ b/src/core/site.jl
@@ -36,7 +36,7 @@ struct Site
     roof_squarefeet
     min_resil_timesteps
     mg_tech_sizes_equal_grid_sizes
-    node
+    node  # TODO validate that multinode Sites do not share node numbers? Or just raise warning
     function Site(;
         latitude::Real, 
         longitude::Real, 

--- a/src/lindistflow/extend.jl
+++ b/src/lindistflow/extend.jl
@@ -42,17 +42,11 @@ end
 function add_complementary_constraints(m::JuMP.AbstractModel, ps::Array{REoptInputs, 1})
     for p in ps
         _n = string("_", p.node)
-
-        b_n = "b"*_n
-        m[Symbol(b_n)] = @variable(m, [p.time_steps], base_name=b_n, Bin)
-    
-        @constraint(m, [t in p.time_steps],
-            m[Symbol("dvGridPurchase"*_n)][t] - (1 - m[Symbol(b_n)][t]) * 1.0E7 <= 0
-        )
-
-        @constraint(m, [t in p.time_steps],
-            m[Symbol("TotalExport"*_n)][t] - m[Symbol(b_n)][t] * 1.0E7 <= 0
-        )
+        for (i, e) in zip(m[Symbol("dvGridPurchase"*_n)], m[Symbol("TotalExport"*_n)])
+            @constraint(m,
+                [i, e] in MOI.SOS1([1.0, 2.0])
+            )
+        end
     end
 end
 

--- a/src/lindistflow/extend.jl
+++ b/src/lindistflow/extend.jl
@@ -34,10 +34,6 @@ function add_expressions(m::JuMP.AbstractModel, ps::Array{REoptInputs, 1})
                 +  m[Symbol("dvNEMexport"*_n)][tech, t] 
                 for tech in p.techs
             )
-            + sum(
-                m[Symbol("dvStorageExport"*_n)][b, u, t] 
-                for b in p.storage.types, u in p.storage.export_bins
-            )  # TODO rm dvStorageExport from REoptLite?
         )
     end
 end

--- a/src/lindistflow/extend.jl
+++ b/src/lindistflow/extend.jl
@@ -1,0 +1,71 @@
+"""
+Outline:
+1. Construct LDF.Inputs from openDSS file, load dict
+2. Add power flow constraints to m, 
+    - set Pⱼ's = -1 * (dvGridPurchase_j - dvWHLexport_j - dvNEMexport_j)
+3. solve model
+"""
+
+function LDF.build_ldf!(m::JuMP.AbstractModel, p::Inputs, reoptnodes::Array{String, 1})
+
+    LDF.add_variables(m, p)
+    LDF.constrain_power_balance(m, p)
+    LDF.constrain_substation_voltage(m, p)
+    LDF.constrain_KVL(m, p)
+    LDF.constrain_loads(m, p, reoptnodes)
+    LDF.constrain_bounds(m, p)
+
+end
+
+function LDF.constrain_loads(m::JuMP.AbstractModel, p::LDF.Inputs, reoptnodes::Array{String, 1})
+
+    Pⱼ = m[:Pⱼ]
+    Qⱼ = m[:Qⱼ]
+
+    for j in p.busses
+        if j in keys(p.Pload)
+            if parse(Int, j) in reoptnodes
+                j_int = parse(Int, j)
+                i = indexin([j_int], reoptnodes)[1]
+
+                @constraint(m, [t in 1:p.Ntimesteps],
+                    Pⱼ[j,t] == 1e3/p.Sbase * (  # 1e3 b/c REopt values in kW
+                        - m[Symbol("dvNetGridDraw_" * j)][t]
+                    )
+                )
+            else
+                @constraint(m, [t in 1:p.Ntimesteps],
+                    Pⱼ[j,t] == -p.Pload[j][t]
+                )
+            end
+        elseif j != p.substation_bus
+            @constraint(m, [t in 1:p.Ntimesteps],
+                Pⱼ[j,t] == 0
+            )
+        end
+        
+        if j in keys(p.Qload)
+            if j in reoptnodes
+                @constraint(m, [t in 1:p.Ntimesteps],
+                    Qⱼ[j,t] == 1e3/p.Sbase * (  # 1e3 b/c REopt values in kW
+                        - m[Symbol("dvNetGridDraw_" * j)][t] * p.pf
+                    )
+                )
+            else
+                @constraint(m, [t in 1:p.Ntimesteps],
+                    Qⱼ[j,t] == -p.Qload[j][t]
+                )
+            end
+        elseif j != p.substation_bus
+            @constraint(m, [t in 1:p.Ntimesteps],
+                Qⱼ[j,t] == 0
+            )
+        end
+    end
+    p.Nequality_cons += 2 * (p.Nnodes - 1) * p.Ntimesteps
+end
+
+
+function run_reopt(m::JuMP.AbstractModel, p::REoptInputs, ldf::LDF.Inputs)
+
+end

--- a/test/data/car10linecodes.dss
+++ b/test/data/car10linecodes.dss
@@ -1,0 +1,42 @@
+New object=circuit.car38
+~ basekv=1 Bus1=0 pu=1.00 phases=1 R1=0 X1=0.0001
+
+New linecode.0_1 nphases=1 BaseFreq=60
+~ rmatrix = [.0242]
+~ xmatrix = [.00482]
+
+New linecode.1_2 nphases=1 BaseFreq=60
+~ rmatrix = [.2273]
+~ xmatrix = [.07435]
+
+New linecode.2_3 nphases=1 BaseFreq=60
+~ rmatrix = [.0763]
+~ xmatrix = [.0182]
+
+New linecode.2_4 nphases=1 BaseFreq=60
+~ rmatrix = [.0436]
+~ xmatrix = [.01427]
+
+New linecode.4_5 nphases=1 BaseFreq=60
+~ rmatrix = [.0258]
+~ xmatrix = [.00844]
+
+New linecode.5_6 nphases=1 BaseFreq=60
+~ rmatrix = [.0105]
+~ xmatrix = [.00107]
+
+New linecode.6_7 nphases=1 BaseFreq=60
+~ rmatrix = [.0232]
+~ xmatrix = [.00236]
+
+New linecode.7_8 nphases=1 BaseFreq=60
+~ rmatrix = [.0751]
+~ xmatrix = [.0267]
+
+New linecode.8_9 nphases=1 BaseFreq=60
+~ rmatrix = [.1144]
+~ xmatrix = [.0273]
+
+New linecode.9_10 nphases=1 BaseFreq=60
+~ rmatrix = [.1903]
+~ xmatrix = [.0677]

--- a/test/data/car10lines.dss
+++ b/test/data/car10lines.dss
@@ -1,0 +1,10 @@
+New Line.L0_1     Phases=1 Bus1=0.1        Bus2=1.1        LineCode=0_1   Length=1
+New Line.L1_2     Phases=1 Bus1=1.1        Bus2=2.1        LineCode=1_2   Length=1
+New Line.L2_3     Phases=1 Bus1=2.1        Bus2=3.1        LineCode=2_3   Length=1
+New Line.L2_4     Phases=1 Bus1=2.1        Bus2=4.1        LineCode=2_4   Length=1
+New Line.L4_5     Phases=1 Bus1=4.1        Bus2=5.1        LineCode=4_5   Length=1
+New Line.L5_6     Phases=1 Bus1=5.1        Bus2=6.1        LineCode=5_6   Length=1
+New Line.L6_7     Phases=1 Bus1=6.1        Bus2=7.1        LineCode=6_7   Length=1
+New Line.L7_8     Phases=1 Bus1=7.1        Bus2=8.1        LineCode=7_8   Length=1
+New Line.L8_9     Phases=1 Bus1=8.1        Bus2=9.1        LineCode=8_9   Length=1
+New Line.L9_10    Phases=1 Bus1=9.1        Bus2=10.1       LineCode=9_10  Length=1

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -36,6 +36,8 @@ julia> Pkg.test("REoptLite"; test_args=["Cbc"])
 
 nlaws 200721: only running Cbc tests here b/c cannot get CPLEX and Xpress licences on to Github
     servers (runtests.jl is automated in Github Actions with ci.yml).
+
+TODO: combine tests into one file and pass in Solver
 =#
 
 @testset "REoptLite.jl" begin

--- a/test/scenarios/monthly_rate.json
+++ b/test/scenarios/monthly_rate.json
@@ -2,7 +2,7 @@
     "Site": {
         "longitude": -91.7337,
         "latitude": 35.2468,
-        "node": 2
+        "node": 10
     },
     "PV": {
         "macrs_bonus_pct": 0.0,

--- a/test/scenarios/monthly_rate.json
+++ b/test/scenarios/monthly_rate.json
@@ -22,7 +22,8 @@
     "ElectricLoad": {
         "doe_reference_name": "MidriseApartment",
         "annual_kwh": 259525.0,
-        "city": "Atlanta"
+        "city": "Atlanta",
+        "year": 2017
     },
     "Storage": {
         "max_kwh": 0.0,

--- a/test/scenarios/pv_storage.json
+++ b/test/scenarios/pv_storage.json
@@ -3,7 +3,8 @@
         "longitude": -118.1164613,
         "latitude": 34.5794343,
         "roof_squarefeet": 5000.0,
-        "land_acres": 1.0
+        "land_acres": 1.0,
+        "node": 3
     },
     "PV": {
         "macrs_bonus_pct": 0.4,

--- a/test/scenarios/pv_storage.json
+++ b/test/scenarios/pv_storage.json
@@ -23,7 +23,8 @@
     "ElectricLoad": {
         "doe_reference_name": "RetailStore",
         "annual_kwh": 10000000.0,
-        "city": "LosAngeles"
+        "city": "LosAngeles",
+        "year": 2017
     },
     "Storage": {
         "total_rebate_per_kw": 100.0,

--- a/test/test_with_cplex.jl
+++ b/test/test_with_cplex.jl
@@ -98,7 +98,7 @@ end
         REoptInputs("./scenarios/monthly_rate.json"),
     ];
     results = run_reopt(m, ps)
-    @test results[1]["Financial"]["lcc_us_dollars"] + results[2]["Financial"]["lcc_us_dollars"] ≈ 1.23887e7 + 437169.0 rtol=1e-5
+    @test results[3]["Financial"]["lcc_us_dollars"] + results[10]["Financial"]["lcc_us_dollars"] ≈ 1.23887e7 + 437169.0 rtol=1e-5
 end
 
 
@@ -131,11 +131,11 @@ end
     add_objective!(m, ps)
     optimize!(m)
 
-    results = reopt_results(m, ps)  # taking ~ 5 minutes !
+    results = reopt_results(m, ps)
     @test results[10]["Financial"]["lcc_us_dollars"] + results[3]["Financial"]["lcc_us_dollars"] ≈ 1.23887e7 + 437169.0 rtol=1e-5
     P0 = value.(m[:Pⱼ]["0",:]).data * ldf_inputs.Sbase / 1e3;  # converting to kW
     TotalGridPurchases = value.(m[:dvGridPurchase_3]).data + value.(m[:dvGridPurchase_10]).data; 
-    @test maximum(TotalGridPurchases) ≈ maximum(P0) rtol = 1e-5
+    @test maximum(TotalGridPurchases) ≈ maximum(P0) rtol = 1e-5  # lossless model
 end
 
 

--- a/test/test_with_xpress.jl
+++ b/test/test_with_xpress.jl
@@ -49,7 +49,8 @@ using REoptLite
     results = run_reopt(model, inputs)
 
     @test results["PV"]["size_kw"] ≈ 70.3084 atol=0.01
-    @test results["Financial"]["lcc_us_dollars"] ≈ 430747.0 rtol=1e-5 # with levelization_factor hack the LCC is within 5e-5 of REopt Lite API LCC
+    @test results["Financial"]["lcc_us_dollars"] ≈ 430747.0 rtol=1e-5 
+    # with levelization_factor hack the LCC is within 5e-5 of REopt Lite API LCC
     @test all(x == 0.0 for x in results["PV"]["year_one_to_load_series_kw"][1:744])
 end
 


### PR DESCRIPTION
- src/lindistflow/extend.jl allows adding power flow constraints to mulitiple REopt nodes
- storage is in general not allowed to export to the grid, and we have removed storage exporting from the API
